### PR TITLE
Samael gray grenade projectile texture

### DIFF
--- a/Defs/Ammo/Grenade/20x42mmGrenade.xml
+++ b/Defs/Ammo/Grenade/20x42mmGrenade.xml
@@ -123,7 +123,7 @@
 	<ThingDef Name="Base20x42mmGrenadeBullet" ParentName="BaseBullet" Abstract="true">
 		<thingClass>CombatExtended.ProjectileCE_Explosive</thingClass>
 		<graphicData>
-			<texPath>Things/Projectile/Bullet_Big</texPath>
+			<texPath>Things/Projectile/LauncherShot</texPath>
 			<graphicClass>Graphic_Single</graphicClass>
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">

--- a/Defs/Ammo/Grenade/20x42mmGrenade.xml
+++ b/Defs/Ammo/Grenade/20x42mmGrenade.xml
@@ -125,6 +125,7 @@
 		<graphicData>
 			<texPath>Things/Projectile/LauncherShot</texPath>
 			<graphicClass>Graphic_Single</graphicClass>
+			<drawSize>(0.3,0.3)</drawSize>
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<speed>62</speed>

--- a/Defs/Ammo/Grenade/25x40mmGrenade.xml
+++ b/Defs/Ammo/Grenade/25x40mmGrenade.xml
@@ -126,6 +126,7 @@
     <graphicData>
       <texPath>Things/Projectile/LauncherShot</texPath>
       <graphicClass>Graphic_Single</graphicClass>
+      <drawSize>(0.35,0.35)</drawSize>
     </graphicData>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
       <speed>42</speed>

--- a/Defs/Ammo/Grenade/25x40mmGrenade.xml
+++ b/Defs/Ammo/Grenade/25x40mmGrenade.xml
@@ -124,7 +124,7 @@
   <ThingDef Name="Base25x40mmGrenadeBullet" ParentName="BaseBullet" Abstract="true">
     <thingClass>CombatExtended.ProjectileCE_Explosive</thingClass>
     <graphicData>
-      <texPath>Things/Projectile/Bullet_Big</texPath>
+      <texPath>Things/Projectile/LauncherShot</texPath>
       <graphicClass>Graphic_Single</graphicClass>
     </graphicData>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">

--- a/Defs/Ammo/Grenade/25x59mmGrenade.xml
+++ b/Defs/Ammo/Grenade/25x59mmGrenade.xml
@@ -124,7 +124,7 @@
 	<ThingDef Name="Base25x59mmGrenadeBullet" ParentName="BaseBullet" Abstract="true">
 		<thingClass>CombatExtended.ProjectileCE_Explosive</thingClass>
 		<graphicData>
-			<texPath>Things/Projectile/Bullet_Big</texPath>
+			<texPath>Things/Projectile/LauncherShot</texPath>
 			<graphicClass>Graphic_Single</graphicClass>
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">

--- a/Defs/Ammo/Grenade/25x59mmGrenade.xml
+++ b/Defs/Ammo/Grenade/25x59mmGrenade.xml
@@ -126,6 +126,7 @@
 		<graphicData>
 			<texPath>Things/Projectile/LauncherShot</texPath>
 			<graphicClass>Graphic_Single</graphicClass>
+			<drawSize>(0.35,0.35)</drawSize>
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<speed>85</speed>

--- a/Defs/Ammo/Grenade/30x29mmGrenade.xml
+++ b/Defs/Ammo/Grenade/30x29mmGrenade.xml
@@ -128,6 +128,7 @@
     <graphicData>
       <texPath>Things/Projectile/LauncherShot</texPath>
       <graphicClass>Graphic_Single</graphicClass>
+      <drawSize>(0.4,0.4)</drawSize>
     </graphicData>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
       <speed>37</speed>

--- a/Defs/Ammo/Grenade/30x29mmGrenade.xml
+++ b/Defs/Ammo/Grenade/30x29mmGrenade.xml
@@ -126,7 +126,7 @@
   <ThingDef Name="Base30x29mmGrenadeBullet" ParentName="BaseBullet" Abstract="true">
     <thingClass>CombatExtended.ProjectileCE_Explosive</thingClass>
     <graphicData>
-      <texPath>Things/Projectile/Bullet_Big</texPath>
+      <texPath>Things/Projectile/LauncherShot</texPath>
       <graphicClass>Graphic_Single</graphicClass>
     </graphicData>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">

--- a/Defs/Ammo/Grenade/35x32mmSRGrenade.xml
+++ b/Defs/Ammo/Grenade/35x32mmSRGrenade.xml
@@ -125,6 +125,7 @@
 		<graphicData>
 			<texPath>Things/Projectile/LauncherShot</texPath>
 			<graphicClass>Graphic_Single</graphicClass>
+			<drawSize>(0.45,0.45)</drawSize>
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<speed>38</speed>

--- a/Defs/Ammo/Grenade/35x32mmSRGrenade.xml
+++ b/Defs/Ammo/Grenade/35x32mmSRGrenade.xml
@@ -123,7 +123,7 @@
 
 	<ThingDef Name="Base35x32mmSRGrenadeBullet" ParentName="BaseBullet" Abstract="true">
 		<graphicData>
-			<texPath>Things/Projectile/Bullet_Big</texPath>
+			<texPath>Things/Projectile/LauncherShot</texPath>
 			<graphicClass>Graphic_Single</graphicClass>
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">

--- a/Defs/Ammo/Grenade/40x46mmGrenade.xml
+++ b/Defs/Ammo/Grenade/40x46mmGrenade.xml
@@ -139,7 +139,7 @@
   <ThingDef Name="Base40x46mmGrenadeBullet" ParentName="BaseBullet" Abstract="true">
     <thingClass>CombatExtended.ProjectileCE_Explosive</thingClass>
     <graphicData>
-      <texPath>Things/Projectile/Bullet_Big</texPath>
+      <texPath>Things/Projectile/LauncherShot</texPath>
       <graphicClass>Graphic_Single</graphicClass>
     </graphicData>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">

--- a/Defs/Ammo/Grenade/40x46mmGrenade.xml
+++ b/Defs/Ammo/Grenade/40x46mmGrenade.xml
@@ -141,6 +141,7 @@
     <graphicData>
       <texPath>Things/Projectile/LauncherShot</texPath>
       <graphicClass>Graphic_Single</graphicClass>
+      <drawSize>(0.5,0.5)</drawSize>
     </graphicData>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
       <speed>20</speed>

--- a/Defs/Ammo/Grenade/40x47mmGrenade.xml
+++ b/Defs/Ammo/Grenade/40x47mmGrenade.xml
@@ -109,7 +109,7 @@
 	<ThingDef Name="Base40x47mmGrenadeBullet" ParentName="BaseBullet" Abstract="true">
 		<thingClass>CombatExtended.ProjectileCE_Explosive</thingClass>
 		<graphicData>
-			<texPath>Things/Projectile/Bullet_Big</texPath>
+			<texPath>Things/Projectile/LauncherShot</texPath>
 			<graphicClass>Graphic_Single</graphicClass>
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">

--- a/Defs/Ammo/Grenade/40x47mmGrenade.xml
+++ b/Defs/Ammo/Grenade/40x47mmGrenade.xml
@@ -111,6 +111,7 @@
 		<graphicData>
 			<texPath>Things/Projectile/LauncherShot</texPath>
 			<graphicClass>Graphic_Single</graphicClass>
+			<drawSize>(0.5,0.5)</drawSize>
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<speed>20</speed>

--- a/Defs/Ammo/Grenade/40x53mmGrenade.xml
+++ b/Defs/Ammo/Grenade/40x53mmGrenade.xml
@@ -140,7 +140,7 @@
 	<ThingDef Name="Base40x53mmGrenadeBullet" ParentName="BaseBullet" Abstract="true">
 		<thingClass>CombatExtended.ProjectileCE_Explosive</thingClass>
 		<graphicData>
-			<texPath>Things/Projectile/Bullet_Big</texPath>
+			<texPath>Things/Projectile/LauncherShot</texPath>
 			<graphicClass>Graphic_Single</graphicClass>
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">

--- a/Defs/Ammo/Grenade/40x53mmGrenade.xml
+++ b/Defs/Ammo/Grenade/40x53mmGrenade.xml
@@ -142,6 +142,7 @@
 		<graphicData>
 			<texPath>Things/Projectile/LauncherShot</texPath>
 			<graphicClass>Graphic_Single</graphicClass>
+			<drawSize>(0.5,0.5)</drawSize>
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<speed>49</speed>

--- a/Defs/Ammo/Grenade/40x53mmVOG25Grenade.xml
+++ b/Defs/Ammo/Grenade/40x53mmVOG25Grenade.xml
@@ -112,6 +112,7 @@
 		<graphicData>
 			<texPath>Things/Projectile/LauncherShot</texPath>
 			<graphicClass>Graphic_Single</graphicClass>
+			<drawSize>(0.5,0.5)</drawSize>
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<speed>20</speed>

--- a/Defs/Ammo/Grenade/40x53mmVOG25Grenade.xml
+++ b/Defs/Ammo/Grenade/40x53mmVOG25Grenade.xml
@@ -110,7 +110,7 @@
 	<ThingDef Name="Base40x53mmVOG25GrenadeBullet" ParentName="BaseBullet" Abstract="true">
 		<thingClass>CombatExtended.ProjectileCE_Explosive</thingClass>
 		<graphicData>
-			<texPath>Things/Projectile/Bullet_Big</texPath>
+			<texPath>Things/Projectile/LauncherShot</texPath>
 			<graphicClass>Graphic_Single</graphicClass>
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">

--- a/Defs/Ammo/Grenade/50mmGS50Grenade.xml
+++ b/Defs/Ammo/Grenade/50mmGS50Grenade.xml
@@ -110,7 +110,7 @@
 	<ThingDef Name="Base50mmGS50GrenadeBullet" ParentName="BaseBullet" Abstract="true">
 		<thingClass>CombatExtended.ProjectileCE_Explosive</thingClass>
 		<graphicData>
-			<texPath>Things/Projectile/Bullet_Big</texPath>
+			<texPath>Things/Projectile/LauncherShot</texPath>
 			<graphicClass>Graphic_Single</graphicClass>
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">

--- a/Defs/Ammo/Grenade/50mmGS50Grenade.xml
+++ b/Defs/Ammo/Grenade/50mmGS50Grenade.xml
@@ -112,6 +112,7 @@
 		<graphicData>
 			<texPath>Things/Projectile/LauncherShot</texPath>
 			<graphicClass>Graphic_Single</graphicClass>
+			<drawSize>(0.5,0.5)</drawSize>
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<speed>22</speed>

--- a/Defs/Ammo/Grenade/83mmPIATGrenade.xml
+++ b/Defs/Ammo/Grenade/83mmPIATGrenade.xml
@@ -98,7 +98,7 @@
 	<ThingDef Name="Base83mmPIATGrenade" ParentName="BaseBullet" Abstract="true">
 		<thingClass>CombatExtended.ProjectileCE_Explosive</thingClass>
 		<graphicData>
-			<texPath>Things/Projectile/Bullet_Big</texPath>
+			<texPath>Things/Projectile/LauncherShot</texPath>
 			<graphicClass>Graphic_Single</graphicClass>
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">


### PR DESCRIPTION
## Additions

Describe new functionality added by your code, e.g.
- Tribal smoke bombs
- New tribal smoke bomb sprite
- Tribal smoke bomb recipes at smithing bench and crafting spot using prometheum

## Changes

Describe adjustments to existing features made in this merge, e.g.
- Increased regular smoke bomb radius

## References

Links to the associated issues or other related pull requests, e.g.
- Closes #[ISSUE_NUMBER]
- Contributes towards #[ISSUE_NUMBER]

## Reasoning

Why did you choose to implement things this way, e.g.
- Tribals need ways to close distance with pirate raiders
- Smoke bombs allow this while enhancing combat micro
- Thematically appropriate as we already allow tribal prometheum handling
- Easy to implement
- Buffed regular smoke grenades as they are rarely utilized and to justify additional investment

## Alternatives

Describe alternative implementations you have considered, e.g.
- Tribal catapult that launches melee animals into siege camps:
  - Additional use for animals
  - Anachronistic
  - Breaks realism theme

## Testing

Check tests you have performed:
- [ ] Compiles without warnings
- [ ] Game runs without errors
- [ ] (For compatibility patches) ...with and without patched mod loaded
- [ ] Playtested a colony (specify how long)
