### PR TITLE
Fix ranged shield belt users unable to use ranged weapons

### DIFF
--- a/Source/CombatExtended/Harmony/Harmony_CompShield.cs
+++ b/Source/CombatExtended/Harmony/Harmony_CompShield.cs
@@ -14,7 +14,16 @@ namespace CombatExtended.HarmonyCE
     {
         internal static bool Prefix(ref bool __result, Verb verb, CompShield __instance)
         {
-            __result = (__instance.ShieldState != ShieldState.Active) || verb is Verb_MarkForArtillery || !(verb is Verb_LaunchProjectileCE || verb is Verb_LaunchProjectile);
+            if (__instance.Props.blocksRangedWeapons)
+            {
+                __result = (__instance.ShieldState != ShieldState.Active) || verb is Verb_MarkForArtillery || !(verb is Verb_LaunchProjectileCE || verb is Verb_LaunchProjectile);
+            }
+            else
+            {
+                // Let pawns use ranged weapons with Biotech's ranged shield belts
+                __result = true;
+            }
+
             return false;
         }
     }


### PR DESCRIPTION
Let Biotech's ranged shield belt wearers use ranged weapons as with vanilla.

## Additions

Describe new functionality added by your code, e.g.
- Tribal smoke bombs
- New tribal smoke bomb sprite
- Tribal smoke bomb recipes at smithing bench and crafting spot using prometheum

## Changes

Describe adjustments to existing features made in this merge, e.g.
- Increased regular smoke bomb radius

## References

Links to the associated issues or other related pull requests, e.g.
- Closes #[ISSUE_NUMBER]
- Contributes towards #[ISSUE_NUMBER]

## Reasoning

Why did you choose to implement things this way, e.g.
- Tribals need ways to close distance with pirate raiders
- Smoke bombs allow this while enhancing combat micro
- Thematically appropriate as we already allow tribal prometheum handling
- Easy to implement
- Buffed regular smoke grenades as they are rarely utilized and to justify additional investment

## Alternatives

Describe alternative implementations you have considered, e.g.
- Tribal catapult that launches melee animals into siege camps:
  - Additional use for animals
  - Anachronistic
  - Breaks realism theme

## Testing

Check tests you have performed:
- [ ] Compiles without warnings
- [ ] Game runs without errors
- [ ] (For compatibility patches) ...with and without patched mod loaded
- [ ] Playtested a colony (specify how long)
