### PR TITLE
Samael gray mech ammo

### DIFF
--- a/Defs/Ammo/Advanced/66mmThermalBolt.xml
+++ b/Defs/Ammo/Advanced/66mmThermalBolt.xml
@@ -27,7 +27,7 @@
     </graphicData>    
     <statBases>
       <MaxHitPoints>200</MaxHitPoints>
-      <Mass>2.5</Mass>
+      <Mass>2.0</Mass>
       <Bulk>4.11</Bulk>	  
     </statBases>
     <thingCategories>
@@ -47,7 +47,7 @@
       <graphicClass>Graphic_StackCount</graphicClass>
     </graphicData>
     <statBases>
-      <MarketValue>13.32</MarketValue> <!-- value intentionally decreased to help reduce wealth bloat/free silver -->
+      <MarketValue>11.74</MarketValue> <!-- value intentionally decreased to help reduce wealth bloat/free silver -->
     </statBases>
     <ammoClass>GrenadeIncendiary</ammoClass>
     <detonateProjectile>Bullet_66mmThermalBolt_Incendiary</detonateProjectile>
@@ -121,7 +121,7 @@
             <li>Steel</li>
           </thingDefs>
         </filter>
-        <count>26</count>
+        <count>20</count>
       </li>
       <li>
         <filter>
@@ -142,7 +142,7 @@
     <products>
       <Ammo_66mmThermalBolt_Incendiary>5</Ammo_66mmThermalBolt_Incendiary>
     </products>
-    <workAmount>5060</workAmount>  <!-- 10% more work -->
+    <workAmount>4400</workAmount>  <!-- 10% more work -->
   </RecipeDef>
 
 </Defs>

--- a/Defs/Ammo/Advanced/66mmThermalBolt.xml
+++ b/Defs/Ammo/Advanced/66mmThermalBolt.xml
@@ -21,7 +21,7 @@
   <!-- ==================== Ammo ========================== -->
 
   <ThingDef Class="CombatExtended.AmmoDef" Name="66mmThermalBoltBase" ParentName="SpacerSmallAmmoBase" Abstract="True">
-    <description>Mechanoid-built low-velocity thermal bolt designed to be fired from a mortar.</description>
+    <description>Mechanoid-built medium-velocity thermal bolt designed to be fired from a mortar.</description>
     <graphicData>
       <drawSize>0.80</drawSize>
     </graphicData>    
@@ -67,7 +67,7 @@
       <soundAmbient>MortarRound_Ambient</soundAmbient>
       <flyOverhead>true</flyOverhead>
       <dropsCasings>false</dropsCasings>
-      <gravityFactor>5</gravityFactor>
+      <gravityFactor>20</gravityFactor> <!-- value intentionally increased to maek the shells land faster -->
     </projectile>
   </ThingDef>
 

--- a/Defs/ThingDefs_Misc/Weapons_Ranged.xml
+++ b/Defs/ThingDefs_Misc/Weapons_Ranged.xml
@@ -290,12 +290,12 @@
     <researchPrerequisite>CE_Launchers</researchPrerequisite>
   </RecipeDef>
 
-  <!-- ==================== Thermal Bolt Launcher ==================== -->
+  <!-- ==================== Thermal Bolt Projector ==================== -->
 
   <ThingDef ParentName="BaseGunWithQuality">
     <defName>CE_ThermalBoltProjector</defName>
     <label>thermal bolt projector</label>
-    <description>A low-velocity, high-trajectory fire support system deployed by the Pikeman mechanoid. While inaccurate and slow-firing, it remains a potent weapon against static targets.</description>
+    <description>A medium-velocity, low-trajectory fire support system deployed by mechanoids. While inaccurate and slow-firing, it remains a potent weapon against static targets.</description>
     <graphicData>
       <texPath>Things/Weapons/ExplosiveBoltProjector</texPath>
       <graphicClass>Graphic_Single</graphicClass>
@@ -326,7 +326,7 @@
         <defaultProjectile>Bullet_66mmThermalBolt_Incendiary</defaultProjectile>
         <warmupTime>3</warmupTime>
         <minRange>10</minRange>
-        <range>45</range>
+        <range>55</range>
         <burstShotCount>1</burstShotCount>
         <soundCast>Mortar_LaunchA</soundCast>
         <muzzleFlashScale>16</muzzleFlashScale>

--- a/Patches/Vanilla Factions Expanded - Mechanoids/CombinationDefs/CombinationDefs.xml
+++ b/Patches/Vanilla Factions Expanded - Mechanoids/CombinationDefs/CombinationDefs.xml
@@ -729,7 +729,7 @@
 							<li>ComponentIndustrial</li>
 						</thirdItems>
 						<amount>
-							<li>26</li>
+							<li>20</li>
 							<li>2</li>
 							<li>2</li>
 						</amount>

--- a/Patches/Vanilla Factions Expanded - Mechanoids/ThingDefs_Misc/Weapons_Mech.xml
+++ b/Patches/Vanilla Factions Expanded - Mechanoids/ThingDefs_Misc/Weapons_Mech.xml
@@ -420,7 +420,7 @@
         <ThingDef ParentName="BaseGunWithQuality">
           <defName>VFE_AdvancedThermalBoltProjector</defName>
           <label>advanced thermal bolt projector</label>
-          <description>A low-velocity, high-trajectory fire support system deployed by mechanoid Pikeman. The advanced variant features a triple shot system, permitting saturation bombardment.</description>
+          <description>A medium-velocity, low-trajectory fire support system deployed by mechanoids. The advanced variant features a triple shot system, permitting saturation bombardment.</description>
           <graphicData>
             <texPath>Things/Weapons/ExplosiveBoltProjector</texPath>
             <graphicClass>Graphic_Single</graphicClass>
@@ -451,7 +451,7 @@
           <defaultProjectile>Bullet_66mmThermalBolt_Incendiary</defaultProjectile>
           <warmupTime>3</warmupTime>
           <minRange>10</minRange>
-          <range>54</range>
+          <range>62</range>
           <burstShotCount>3</burstShotCount>
           <soundCast>Mortar_LaunchA</soundCast>
           <muzzleFlashScale>16</muzzleFlashScale>


### PR DESCRIPTION
## Additions

Describe new functionality added by your code, e.g.
- Tribal smoke bombs
- New tribal smoke bomb sprite
- Tribal smoke bomb recipes at smithing bench and crafting spot using prometheum

## Changes

Describe adjustments to existing features made in this merge, e.g.
- Increased regular smoke bomb radius

## References

Links to the associated issues or other related pull requests, e.g.
- Closes #[ISSUE_NUMBER]
- Contributes towards #[ISSUE_NUMBER]

## Reasoning

Why did you choose to implement things this way, e.g.
- Tribals need ways to close distance with pirate raiders
- Smoke bombs allow this while enhancing combat micro
- Thematically appropriate as we already allow tribal prometheum handling
- Easy to implement
- Buffed regular smoke grenades as they are rarely utilized and to justify additional investment

## Alternatives

Describe alternative implementations you have considered, e.g.
- Tribal catapult that launches melee animals into siege camps:
  - Additional use for animals
  - Anachronistic
  - Breaks realism theme

## Testing

Check tests you have performed:
- [ ] Compiles without warnings
- [ ] Game runs without errors
- [ ] (For compatibility patches) ...with and without patched mod loaded
- [ ] Playtested a colony (specify how long)
