### PR TITLE
Update HAR compat patch

### DIFF
--- a/Source/CombatExtended/Harmony/Compatibility/Harmony_AlienRace.cs
+++ b/Source/CombatExtended/Harmony/Compatibility/Harmony_AlienRace.cs
@@ -105,7 +105,7 @@ namespace CombatExtended.HarmonyCE.Compatibility
         }
 
         [HarmonyPatch]
-        public static class Harmony_AlienPartGenerator_GetPawnHairMesh
+        public static class Harmony_AlienPartGenerator_GetHumanlikeHeadSetForPawnHelper
         {
             public static bool Prepare()
             {
@@ -114,16 +114,14 @@ namespace CombatExtended.HarmonyCE.Compatibility
 
             public static MethodBase TargetMethod()
             {
-                return AccessTools.Method(typeof(Harmony_PawnRenderer), nameof(Harmony_PawnRenderer.GetHeadMesh));
+                return AccessTools.Method(typeof(Harmony_PawnRenderer), nameof(Harmony_PawnRenderer.GetHumanlikeHeadSetForPawnHelper));
             }
 
             public static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> instructions, ILGenerator generator)
             {
-                yield return new CodeInstruction(OpCodes.Ldarg_0);
-                yield return new CodeInstruction(OpCodes.Ldarg_1);
-                yield return new CodeInstruction(OpCodes.Ldarg_2);
-                yield return new CodeInstruction(OpCodes.Ldarg_3);
-                yield return new CodeInstruction(OpCodes.Call, AccessTools.Method(TypeOf_HarmonyPatches, "GetPawnHairMesh"));
+                yield return new CodeInstruction(OpCodes.Ldarg_0); // lifeStageFactor
+                yield return new CodeInstruction(OpCodes.Ldarg_1); // pawn
+                yield return new CodeInstruction(OpCodes.Call, AccessTools.Method(TypeOf_HarmonyPatches, "GetHumanlikeHeadSetForPawnHelper"));
                 yield return new CodeInstruction(OpCodes.Ret);
             }
         }

--- a/Source/CombatExtended/Harmony/Harmony_PawnRenderer.cs
+++ b/Source/CombatExtended/Harmony/Harmony_PawnRenderer.cs
@@ -56,7 +56,7 @@ namespace CombatExtended.HarmonyCE
         /// Intended to allow an easy point that allow other mods or CE to patch the rendering in runtime
         /// </summary>                
         [MethodImpl(MethodImplOptions.NoInlining)]
-        public static Mesh GetHeadMesh(PawnRenderFlags renderFlags, Pawn pawn, Rot4 headFacing, PawnGraphicSet graphics)
+        public static GraphicMeshSet GetHumanlikeHeadSetForPawnHelper(float lifeStageFactor, Pawn pawn)
         {
             return null;
         }
@@ -243,7 +243,10 @@ namespace CombatExtended.HarmonyCE
                 Vector3 customScale = Vec2ToVec3(GetHeadCustomSize(pawn.def));
                 Vector3 headwearPos = headLoc + Vec2ToVec3(GetHeadCustomOffset(pawn.def));
 
-                Mesh mesh = GetHeadMesh(flags, pawn, headFacing, renderer.graphics) ?? renderer.graphics.HairMeshSet.MeshAt(bodyFacing);
+                // Let other mods such as HAR inject an alternative graphic for the hair/head
+                float lifeStageFactor = pawn.ageTracker.CurLifeStage.bodySizeFactor;
+                GraphicMeshSet gms = GetHumanlikeHeadSetForPawnHelper(lifeStageFactor, pawn);
+                Mesh mesh = gms?.MeshAt(bodyFacing) ?? renderer.graphics.HairMeshSet.MeshAt(bodyFacing);
 
                 for (int i = 0; i < apparelGraphics.Count; i++)
                 {


### PR DESCRIPTION
Fix our HAR compat patch for 1.4 by updating the HAR method that will be called within our pawn rendering compat hook. GetHairMesh() was replaced by GetHumanlikeHeadSetForPawnHelper() on the HAR side.

## Additions

Describe new functionality added by your code, e.g.
- Tribal smoke bombs
- New tribal smoke bomb sprite
- Tribal smoke bomb recipes at smithing bench and crafting spot using prometheum

## Changes

Describe adjustments to existing features made in this merge, e.g.
- Increased regular smoke bomb radius

## References

Links to the associated issues or other related pull requests, e.g.
- Closes #[ISSUE_NUMBER]
- Contributes towards #[ISSUE_NUMBER]

## Reasoning

Why did you choose to implement things this way, e.g.
- Tribals need ways to close distance with pirate raiders
- Smoke bombs allow this while enhancing combat micro
- Thematically appropriate as we already allow tribal prometheum handling
- Easy to implement
- Buffed regular smoke grenades as they are rarely utilized and to justify additional investment

## Alternatives

Describe alternative implementations you have considered, e.g.
- Tribal catapult that launches melee animals into siege camps:
  - Additional use for animals
  - Anachronistic
  - Breaks realism theme

## Testing

Check tests you have performed:
- [ ] Compiles without warnings
- [ ] Game runs without errors
- [ ] (For compatibility patches) ...with and without patched mod loaded
- [ ] Playtested a colony (specify how long)
