### PR TITLE
Hide ammo status and armor reload gizmos for non-colonist pawns

### DIFF
--- a/Source/CombatExtended/CombatExtended/Comps/CompAmmoUser.cs
+++ b/Source/CombatExtended/CombatExtended/Comps/CompAmmoUser.cs
@@ -689,11 +689,14 @@ namespace CombatExtended
 
         public override IEnumerable<Gizmo> CompGetGizmosExtra()
         {
-            GizmoAmmoStatus ammoStatusGizmo = new GizmoAmmoStatus { compAmmo = this };
-            yield return ammoStatusGizmo;
             var mannableComp = turret?.GetMannable();
-            if ((IsEquippedGun && Wielder.Faction == Faction.OfPlayer) || (turret != null && turret.Faction == Faction.OfPlayer && (mannableComp != null || UseAmmo)))
+            var isPlayerControlled = Wielder?.IsColonistPlayerControlled ?? (turret?.Faction == Faction.OfPlayer && (mannableComp != null || UseAmmo));
+
+            if (isPlayerControlled)
             {
+                GizmoAmmoStatus ammoStatusGizmo = new GizmoAmmoStatus { compAmmo = this };
+                yield return ammoStatusGizmo;
+
                 Action action = null;
                 if (IsEquippedGun) action = SyncedTryStartReload;
                 else if (mannableComp != null) action = SyncedTryForceReload;

--- a/Source/CombatExtended/Harmony/Harmony_CompReloadable.cs
+++ b/Source/CombatExtended/Harmony/Harmony_CompReloadable.cs
@@ -20,15 +20,20 @@ namespace CombatExtended.HarmonyCE
                 yield return g;
             }
 
-            yield return new Command_ReloadArmor
+            // Don't show the "reload worn armor" gizmo for non-colonist pawns / pawns in a mental break etc.
+            if (__instance.Wearer.IsColonistPlayerControlled)
             {
-                compReloadable = __instance,
-                action = () => TryReloadArmor(__instance),
-                defaultLabel = (string)"CE_ReloadLabel".Translate() + " worn armor",
-                defaultDesc = "CE_ReloadDesc".Translate(),
-                icon = ContentFinder<Texture2D>.Get("UI/Buttons/Reload", true)
 
-            };
+                yield return new Command_ReloadArmor
+                {
+                    compReloadable = __instance,
+                    action = () => TryReloadArmor(__instance),
+                    defaultLabel = (string)"CE_ReloadLabel".Translate() + " worn armor",
+                    defaultDesc = "CE_ReloadDesc".Translate(),
+                    icon = ContentFinder<Texture2D>.Get("UI/Buttons/Reload", true)
+
+                };
+            }
 
         }
 


### PR DESCRIPTION
For consistency with other related gizmos.

## Additions

Describe new functionality added by your code, e.g.
- Tribal smoke bombs
- New tribal smoke bomb sprite
- Tribal smoke bomb recipes at smithing bench and crafting spot using prometheum

## Changes

Describe adjustments to existing features made in this merge, e.g.
- Increased regular smoke bomb radius

## References

Links to the associated issues or other related pull requests, e.g.
- Closes #[ISSUE_NUMBER]
- Contributes towards #[ISSUE_NUMBER]

## Reasoning

Why did you choose to implement things this way, e.g.
- Tribals need ways to close distance with pirate raiders
- Smoke bombs allow this while enhancing combat micro
- Thematically appropriate as we already allow tribal prometheum handling
- Easy to implement
- Buffed regular smoke grenades as they are rarely utilized and to justify additional investment

## Alternatives

Describe alternative implementations you have considered, e.g.
- Tribal catapult that launches melee animals into siege camps:
  - Additional use for animals
  - Anachronistic
  - Breaks realism theme

## Testing

Check tests you have performed:
- [ ] Compiles without warnings
- [ ] Game runs without errors
- [ ] (For compatibility patches) ...with and without patched mod loaded
- [ ] Playtested a colony (specify how long)
