### PR TITLE
Use mechanoid faction style for mech cluster ammo drop pods

### DIFF
--- a/Source/CombatExtended/CombatExtended/Comps/CompAmmoResupplyOnWakeup.cs
+++ b/Source/CombatExtended/CombatExtended/Comps/CompAmmoResupplyOnWakeup.cs
@@ -130,7 +130,18 @@ namespace CombatExtended
             list.Add(thing);
 
             //If turrets are near-empty or empty, call in ammo droppod
-            DropPodUtility.DropThingsNear(cell, parent.Map, list, 110, false, false, true, true);
+            DropPodUtility.DropThingsNear(
+                cell,
+                parent.Map,
+                list,
+                openDelay: 110,
+                canInstaDropDuringInit: false,
+                leaveSlag: false,
+                canRoofPunch: true,
+                forbid: true,
+                // Use the mechanoid faction as the faction for the drop pods, to match style
+                faction: parent.Faction
+            );
         }
     }
 }


### PR DESCRIPTION
This is the same style used for the pods that drop the cluster itself.

## Additions

Describe new functionality added by your code, e.g.
- Tribal smoke bombs
- New tribal smoke bomb sprite
- Tribal smoke bomb recipes at smithing bench and crafting spot using prometheum

## Changes

Describe adjustments to existing features made in this merge, e.g.
- Increased regular smoke bomb radius

## References

Links to the associated issues or other related pull requests, e.g.
- Closes #[ISSUE_NUMBER]
- Contributes towards #[ISSUE_NUMBER]

## Reasoning

Why did you choose to implement things this way, e.g.
- Tribals need ways to close distance with pirate raiders
- Smoke bombs allow this while enhancing combat micro
- Thematically appropriate as we already allow tribal prometheum handling
- Easy to implement
- Buffed regular smoke grenades as they are rarely utilized and to justify additional investment

## Alternatives

Describe alternative implementations you have considered, e.g.
- Tribal catapult that launches melee animals into siege camps:
  - Additional use for animals
  - Anachronistic
  - Breaks realism theme

## Testing

Check tests you have performed:
- [ ] Compiles without warnings
- [ ] Game runs without errors
- [ ] (For compatibility patches) ...with and without patched mod loaded
- [ ] Playtested a colony (specify how long)
