### PR TITLE
Vwe makeshift hotfix

### DIFF
--- a/Patches/Vanilla Weapons Expanded - Makeshift/RangedIndustrial.xml
+++ b/Patches/Vanilla Weapons Expanded - Makeshift/RangedIndustrial.xml
@@ -359,7 +359,7 @@
 								<hasStandardCommand>true</hasStandardCommand>
 								<defaultProjectile>Bullet_12Gauge_Buck</defaultProjectile>
 								<ticksBetweenBurstShots>2</ticksBetweenBurstShots>
-								<burstShotCount>2</burstShotCount>
+								<!--<burstShotCount>2</burstShotCount>-->
 								<warmupTime>0.6</warmupTime>
 								<range>14</range>
 								<soundCast>Shot_Shotgun</soundCast>

--- a/Patches/Vanilla Weapons Expanded - Makeshift/RangedIndustrial.xml
+++ b/Patches/Vanilla Weapons Expanded - Makeshift/RangedIndustrial.xml
@@ -89,7 +89,6 @@
 						<SwayFactor>1.30</SwayFactor>
 						<Bulk>2.62</Bulk>
 					</statBases>
-					<!--
 					<Properties>
 						<verbClass>CombatExtended.Verb_ShootCE</verbClass>
 						<hasStandardCommand>true</hasStandardCommand>
@@ -100,7 +99,6 @@
 						<soundCastTail>GunTail_Light</soundCastTail>
 						<muzzleFlashScale>9</muzzleFlashScale>
 					</Properties>
-					-->
 					<AmmoUser>
 						<magazineSize>5</magazineSize>
 						<reloadTime>4</reloadTime>
@@ -115,7 +113,7 @@
 						<li>CE_OneHandedWeapon</li>
 					</weaponTags>
 				</li>
-				<li Class="PatchOperationReplace">
+				<!-- <li Class="PatchOperationReplace">
 					<xpath>Defs/ThingDef[defName = "VWE_Gun_MakeshiftPistol"]/verbs</xpath>
 					<value>
 						<verbs>
@@ -131,7 +129,7 @@
 							</li>
 						</verbs>
 					</value>
-				</li>
+				</li> -->
 				<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
 					<defName>VWE_Gun_MakeshiftSMG</defName>
 					<statBases>
@@ -142,10 +140,9 @@
 						<SwayFactor>1.18</SwayFactor>
 						<Bulk>5.62</Bulk>
 					</statBases>
-					<!--
 					<Properties>
 						<recoilAmount>2.02</recoilAmount>
-						<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+						<verbClass>Compatibility.Verb_ShootCEKEK</verbClass>
 						<hasStandardCommand>true</hasStandardCommand>
 						<defaultProjectile>Bullet_9x19mmPara_FMJ</defaultProjectile>
 						<ticksBetweenBurstShots>2</ticksBetweenBurstShots>
@@ -156,7 +153,6 @@
 						<soundCastTail>GunTail_Light</soundCastTail>
 						<muzzleFlashScale>9</muzzleFlashScale>
 					</Properties>
-					-->
 					<AmmoUser>
 						<magazineSize>24</magazineSize>
 						<reloadTime>4.4</reloadTime>
@@ -171,7 +167,7 @@
 						<li>CE_MachineGun</li>
 					</weaponTags>
 				</li>
-				<li Class="PatchOperationReplace">
+				<!-- <li Class="PatchOperationReplace">
 					<xpath>Defs/ThingDef[defName = "VWE_Gun_MakeshiftSMG"]/verbs</xpath>
 					<value>
 						<verbs>
@@ -190,7 +186,7 @@
 							</li>
 						</verbs>
 					</value>
-				</li>
+				</li> -->
 				<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
 					<defName>VWE_Gun_MakeshiftRifle</defName>
 					<statBases>
@@ -201,7 +197,6 @@
 						<SwayFactor>1.68</SwayFactor>
 						<Bulk>11.62</Bulk>
 					</statBases>
-					<!--
 					<Properties>
 						<recoilAmount>1.73</recoilAmount>
 						<verbClass>CombatExtended.Verb_ShootCE</verbClass>
@@ -215,7 +210,6 @@
 						<soundCastTail>GunTail_Medium</soundCastTail>
 						<muzzleFlashScale>9</muzzleFlashScale>
 					</Properties>
-					-->
 					<AmmoUser>
 						<magazineSize>30</magazineSize>
 						<reloadTime>4.6</reloadTime>
@@ -230,7 +224,7 @@
 						<li>CE_AI_AR</li>
 					</weaponTags>
 				</li>
-				<li Class="PatchOperationReplace">
+				<!-- <li Class="PatchOperationReplace">
 					<xpath>Defs/ThingDef[defName = "VWE_Gun_MakeshiftRifle"]/verbs</xpath>
 					<value>
 						<verbs>
@@ -249,7 +243,7 @@
 							</li>
 						</verbs>
 					</value>
-				</li>
+				</li> -->
 				<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
 					<defName>VWE_Gun_MakeshiftLMG</defName>
 					<statBases>
@@ -260,10 +254,9 @@
 						<SwayFactor>1.78</SwayFactor>
 						<Bulk>15.7</Bulk>
 					</statBases>
-					<!--
 					<Properties>
 						<recoilAmount>1.32</recoilAmount>
-						<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+						<verbClass>CombatExtended.Verb_ShootCEKEK</verbClass>
 						<hasStandardCommand>true</hasStandardCommand>
 						<defaultProjectile>Bullet_762x54mmR_FMJ</defaultProjectile>
 						<ticksBetweenBurstShots>7</ticksBetweenBurstShots>
@@ -277,7 +270,6 @@
 							<canTargetLocations>true</canTargetLocations>
 						</targetParams>
 					</Properties>
-					-->
 					<AmmoUser>
 						<magazineSize>50</magazineSize>
 						<reloadTime>5.2</reloadTime>
@@ -292,7 +284,7 @@
 						<li>CE_MachineGun</li>
 					</weaponTags>
 				</li>
-				<li Class="PatchOperationReplace">
+				<!-- <li Class="PatchOperationReplace">
 					<xpath>Defs/ThingDef[defName = "VWE_Gun_MakeshiftLMG"]/verbs</xpath>
 					<value>
 						<verbs>
@@ -314,7 +306,7 @@
 							</li>
 						</verbs>
 					</value>
-				</li>
+				</li> -->
 				<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
 					<defName>VWE_Gun_MakeshiftShotgun</defName>
 					<statBases>
@@ -325,21 +317,19 @@
 						<SwayFactor>1.48</SwayFactor>
 						<Bulk>9.6</Bulk>
 					</statBases>
-					<!--
 					<Properties>
 						<recoilAmount>1.69</recoilAmount>
-						<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+						<verbClass>CombatExtended.Verb_ShootCEKEK</verbClass>
 						<hasStandardCommand>true</hasStandardCommand>
 						<defaultProjectile>Bullet_12Gauge_Buck</defaultProjectile>
 						<ticksBetweenBurstShots>2</ticksBetweenBurstShots>
-						<burstShotCount>2</burstShotCount>
+						<!--<burstShotCount>2</burstShotCount>-->
 						<warmupTime>0.6</warmupTime>
 						<range>14</range>
 						<soundCast>Shot_Shotgun</soundCast>
 						<soundCastTail>GunTail_Heavy</soundCastTail>
 						<muzzleFlashScale>9</muzzleFlashScale>
 					</Properties>
-					-->
 					<AmmoUser>
 						<magazineSize>2</magazineSize>
 						<reloadTime>2</reloadTime>
@@ -352,26 +342,26 @@
 						<li>CE_AI_BROOM</li>
 					</weaponTags>
 				</li>
-				<li Class="PatchOperationReplace">
-					<xpath>Defs/ThingDef[defName = "VWE_Gun_MakeshiftShotgun"]/verbs</xpath>
-					<value>
-						<verbs>
-							<li Class="CombatExtended.VerbPropertiesCE">
-								<recoilAmount>1.69</recoilAmount>
-								<verbClass>CombatExtended.Verb_ShootCE</verbClass>
-								<hasStandardCommand>true</hasStandardCommand>
-								<defaultProjectile>Bullet_12Gauge_Buck</defaultProjectile>
-								<ticksBetweenBurstShots>2</ticksBetweenBurstShots>
-								<!--<burstShotCount>2</burstShotCount>-->
-								<warmupTime>0.6</warmupTime>
-								<range>14</range>
-								<soundCast>Shot_Shotgun</soundCast>
-								<soundCastTail>GunTail_Heavy</soundCastTail>
-								<muzzleFlashScale>9</muzzleFlashScale>
-							</li>
-						</verbs>
-					</value>
-				</li>
+				<!-- <li Class="PatchOperationReplace"> -->
+					<!-- <xpath>Defs/ThingDef[defName = "VWE_Gun_MakeshiftShotgun"]/verbs</xpath> -->
+					<!-- <value> -->
+						<!-- <verbs> -->
+							<!-- <li Class="CombatExtended.VerbPropertiesCE"> -->
+								<!-- <recoilAmount>1.69</recoilAmount> -->
+								<!-- <verbClass>CombatExtended.Verb_ShootCE</verbClass> -->
+								<!-- <hasStandardCommand>true</hasStandardCommand> -->
+								<!-- <defaultProjectile>Bullet_12Gauge_Buck</defaultProjectile> -->
+								<!-- <ticksBetweenBurstShots>2</ticksBetweenBurstShots> -->
+								<!-- <burstShotCount>2</burstShotCount> -->
+								<!-- <warmupTime>0.6</warmupTime> -->
+								<!-- <range>14</range> -->
+								<!-- <soundCast>Shot_Shotgun</soundCast> -->
+								<!-- <soundCastTail>GunTail_Heavy</soundCastTail> -->
+								<!-- <muzzleFlashScale>9</muzzleFlashScale> -->
+							<!-- </li> -->
+						<!-- </verbs> -->
+					<!-- </value> -->
+				<!-- </li> -->
 			</operations>
 		</match>
 	</Operation>

--- a/Patches/Vanilla Weapons Expanded - Makeshift/RangedIndustrial.xml
+++ b/Patches/Vanilla Weapons Expanded - Makeshift/RangedIndustrial.xml
@@ -142,7 +142,7 @@
 					</statBases>
 					<Properties>
 						<recoilAmount>2.02</recoilAmount>
-						<verbClass>Compatibility.Verb_ShootCEKEK</verbClass>
+						<verbClass>CombatExtended.Compatibility.Verb_ShootCEKEK</verbClass>
 						<hasStandardCommand>true</hasStandardCommand>
 						<defaultProjectile>Bullet_9x19mmPara_FMJ</defaultProjectile>
 						<ticksBetweenBurstShots>2</ticksBetweenBurstShots>
@@ -256,7 +256,7 @@
 					</statBases>
 					<Properties>
 						<recoilAmount>1.32</recoilAmount>
-						<verbClass>CombatExtended.Verb_ShootCEKEK</verbClass>
+						<verbClass>CombatExtended.Compatibility.Verb_ShootCEKEK</verbClass>
 						<hasStandardCommand>true</hasStandardCommand>
 						<defaultProjectile>Bullet_762x54mmR_FMJ</defaultProjectile>
 						<ticksBetweenBurstShots>7</ticksBetweenBurstShots>
@@ -319,7 +319,7 @@
 					</statBases>
 					<Properties>
 						<recoilAmount>1.69</recoilAmount>
-						<verbClass>CombatExtended.Verb_ShootCEKEK</verbClass>
+						<verbClass>CombatExtended.Compatibility.Verb_ShootCEKEK</verbClass>
 						<hasStandardCommand>true</hasStandardCommand>
 						<defaultProjectile>Bullet_12Gauge_Buck</defaultProjectile>
 						<ticksBetweenBurstShots>2</ticksBetweenBurstShots>

--- a/Patches/Vanilla Weapons Expanded - Makeshift/RangedIndustrial.xml
+++ b/Patches/Vanilla Weapons Expanded - Makeshift/RangedIndustrial.xml
@@ -113,23 +113,6 @@
 						<li>CE_OneHandedWeapon</li>
 					</weaponTags>
 				</li>
-				<!-- <li Class="PatchOperationReplace">
-					<xpath>Defs/ThingDef[defName = "VWE_Gun_MakeshiftPistol"]/verbs</xpath>
-					<value>
-						<verbs>
-							<li Class="CombatExtended.VerbPropertiesCE">
-								<verbClass>CombatExtended.Verb_ShootCE</verbClass>
-								<hasStandardCommand>true</hasStandardCommand>
-								<defaultProjectile>Bullet_9x19mmPara_FMJ</defaultProjectile>
-								<warmupTime>0.2</warmupTime>
-								<range>10</range>
-								<soundCast>Shot_Autopistol</soundCast>
-								<soundCastTail>GunTail_Light</soundCastTail>
-								<muzzleFlashScale>9</muzzleFlashScale>
-							</li>
-						</verbs>
-					</value>
-				</li> -->
 				<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
 					<defName>VWE_Gun_MakeshiftSMG</defName>
 					<statBases>
@@ -167,26 +150,6 @@
 						<li>CE_MachineGun</li>
 					</weaponTags>
 				</li>
-				<!-- <li Class="PatchOperationReplace">
-					<xpath>Defs/ThingDef[defName = "VWE_Gun_MakeshiftSMG"]/verbs</xpath>
-					<value>
-						<verbs>
-							<li Class="CombatExtended.VerbPropertiesCE">
-								<recoilAmount>2.02</recoilAmount>
-								<verbClass>CombatExtended.Verb_ShootCE</verbClass>
-								<hasStandardCommand>true</hasStandardCommand>
-								<defaultProjectile>Bullet_9x19mmPara_FMJ</defaultProjectile>
-								<ticksBetweenBurstShots>2</ticksBetweenBurstShots>
-								<burstShotCount>6</burstShotCount>
-								<warmupTime>0.6</warmupTime>
-								<range>22</range>
-								<soundCast>Shot_MachinePistol</soundCast>
-								<soundCastTail>GunTail_Light</soundCastTail>
-								<muzzleFlashScale>9</muzzleFlashScale>
-							</li>
-						</verbs>
-					</value>
-				</li> -->
 				<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
 					<defName>VWE_Gun_MakeshiftRifle</defName>
 					<statBases>
@@ -224,26 +187,6 @@
 						<li>CE_AI_AR</li>
 					</weaponTags>
 				</li>
-				<!-- <li Class="PatchOperationReplace">
-					<xpath>Defs/ThingDef[defName = "VWE_Gun_MakeshiftRifle"]/verbs</xpath>
-					<value>
-						<verbs>
-							<li Class="CombatExtended.VerbPropertiesCE">
-								<recoilAmount>1.73</recoilAmount>
-								<verbClass>CombatExtended.Verb_ShootCE</verbClass>
-								<hasStandardCommand>true</hasStandardCommand>
-								<defaultProjectile>Bullet_762x39mmSoviet_FMJ</defaultProjectile>
-								<ticksBetweenBurstShots>2</ticksBetweenBurstShots>
-								<burstShotCount>5</burstShotCount>
-								<warmupTime>1.1</warmupTime>
-								<range>44</range>
-								<soundCast>Shot_AssaultRifle</soundCast>
-								<soundCastTail>GunTail_Medium</soundCastTail>
-								<muzzleFlashScale>9</muzzleFlashScale>
-							</li>
-						</verbs>
-					</value>
-				</li> -->
 				<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
 					<defName>VWE_Gun_MakeshiftLMG</defName>
 					<statBases>
@@ -284,29 +227,6 @@
 						<li>CE_MachineGun</li>
 					</weaponTags>
 				</li>
-				<!-- <li Class="PatchOperationReplace">
-					<xpath>Defs/ThingDef[defName = "VWE_Gun_MakeshiftLMG"]/verbs</xpath>
-					<value>
-						<verbs>
-							<li Class="CombatExtended.VerbPropertiesCE">
-								<recoilAmount>1.32</recoilAmount>
-								<verbClass>CombatExtended.Verb_ShootCE</verbClass>
-								<hasStandardCommand>true</hasStandardCommand>
-								<defaultProjectile>Bullet_762x54mmR_FMJ</defaultProjectile>
-								<ticksBetweenBurstShots>7</ticksBetweenBurstShots>
-								<burstShotCount>19</burstShotCount>
-								<warmupTime>1.3</warmupTime>
-								<range>58</range>
-								<soundCast>Shot_Minigun</soundCast>
-								<soundCastTail>GunTail_Medium</soundCastTail>
-								<muzzleFlashScale>9</muzzleFlashScale>
-								<targetParams>
-									<canTargetLocations>true</canTargetLocations>
-								</targetParams>
-							</li>
-						</verbs>
-					</value>
-				</li> -->
 				<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
 					<defName>VWE_Gun_MakeshiftShotgun</defName>
 					<statBases>
@@ -342,26 +262,6 @@
 						<li>CE_AI_BROOM</li>
 					</weaponTags>
 				</li>
-				<!-- <li Class="PatchOperationReplace"> -->
-					<!-- <xpath>Defs/ThingDef[defName = "VWE_Gun_MakeshiftShotgun"]/verbs</xpath> -->
-					<!-- <value> -->
-						<!-- <verbs> -->
-							<!-- <li Class="CombatExtended.VerbPropertiesCE"> -->
-								<!-- <recoilAmount>1.69</recoilAmount> -->
-								<!-- <verbClass>CombatExtended.Verb_ShootCE</verbClass> -->
-								<!-- <hasStandardCommand>true</hasStandardCommand> -->
-								<!-- <defaultProjectile>Bullet_12Gauge_Buck</defaultProjectile> -->
-								<!-- <ticksBetweenBurstShots>2</ticksBetweenBurstShots> -->
-								<!-- <burstShotCount>2</burstShotCount> -->
-								<!-- <warmupTime>0.6</warmupTime> -->
-								<!-- <range>14</range> -->
-								<!-- <soundCast>Shot_Shotgun</soundCast> -->
-								<!-- <soundCastTail>GunTail_Heavy</soundCastTail> -->
-								<!-- <muzzleFlashScale>9</muzzleFlashScale> -->
-							<!-- </li> -->
-						<!-- </verbs> -->
-					<!-- </value> -->
-				<!-- </li> -->
 			</operations>
 		</match>
 	</Operation>

--- a/Patches/Vanilla Weapons Expanded - Makeshift/RangedIndustrial.xml
+++ b/Patches/Vanilla Weapons Expanded - Makeshift/RangedIndustrial.xml
@@ -345,6 +345,9 @@
 						<reloadTime>2</reloadTime>
 						<ammoSet>AmmoSet_12Gauge</ammoSet>
 					</AmmoUser>
+					<FireModes>
+						<aiAimMode>Snapshot</aiAimMode>
+					</FireModes>
 					<weaponTags>
 						<li>CE_AI_BROOM</li>
 					</weaponTags>

--- a/Patches/Vanilla Weapons Expanded - Makeshift/RangedIndustrial.xml
+++ b/Patches/Vanilla Weapons Expanded - Makeshift/RangedIndustrial.xml
@@ -89,6 +89,7 @@
 						<SwayFactor>1.30</SwayFactor>
 						<Bulk>2.62</Bulk>
 					</statBases>
+					<!--
 					<Properties>
 						<verbClass>CombatExtended.Verb_ShootCE</verbClass>
 						<hasStandardCommand>true</hasStandardCommand>
@@ -99,6 +100,7 @@
 						<soundCastTail>GunTail_Light</soundCastTail>
 						<muzzleFlashScale>9</muzzleFlashScale>
 					</Properties>
+					-->
 					<AmmoUser>
 						<magazineSize>5</magazineSize>
 						<reloadTime>4</reloadTime>
@@ -113,6 +115,23 @@
 						<li>CE_OneHandedWeapon</li>
 					</weaponTags>
 				</li>
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName = "VWE_Gun_MakeshiftPistol"]/verbs</xpath>
+					<value>
+						<verbs>
+							<li Class="CombatExtended.VerbPropertiesCE">
+								<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+								<hasStandardCommand>true</hasStandardCommand>
+								<defaultProjectile>Bullet_9x19mmPara_FMJ</defaultProjectile>
+								<warmupTime>0.2</warmupTime>
+								<range>10</range>
+								<soundCast>Shot_Autopistol</soundCast>
+								<soundCastTail>GunTail_Light</soundCastTail>
+								<muzzleFlashScale>9</muzzleFlashScale>
+							</li>
+						</verbs>
+					</value>
+				</li>
 				<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
 					<defName>VWE_Gun_MakeshiftSMG</defName>
 					<statBases>
@@ -123,6 +142,7 @@
 						<SwayFactor>1.18</SwayFactor>
 						<Bulk>5.62</Bulk>
 					</statBases>
+					<!--
 					<Properties>
 						<recoilAmount>2.02</recoilAmount>
 						<verbClass>CombatExtended.Verb_ShootCE</verbClass>
@@ -136,6 +156,7 @@
 						<soundCastTail>GunTail_Light</soundCastTail>
 						<muzzleFlashScale>9</muzzleFlashScale>
 					</Properties>
+					-->
 					<AmmoUser>
 						<magazineSize>24</magazineSize>
 						<reloadTime>4.4</reloadTime>
@@ -150,6 +171,26 @@
 						<li>CE_MachineGun</li>
 					</weaponTags>
 				</li>
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName = "VWE_Gun_MakeshiftSMG"]/verbs</xpath>
+					<value>
+						<verbs>
+							<li Class="CombatExtended.VerbPropertiesCE">
+								<recoilAmount>2.02</recoilAmount>
+								<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+								<hasStandardCommand>true</hasStandardCommand>
+								<defaultProjectile>Bullet_9x19mmPara_FMJ</defaultProjectile>
+								<ticksBetweenBurstShots>2</ticksBetweenBurstShots>
+								<burstShotCount>6</burstShotCount>
+								<warmupTime>0.6</warmupTime>
+								<range>22</range>
+								<soundCast>Shot_MachinePistol</soundCast>
+								<soundCastTail>GunTail_Light</soundCastTail>
+								<muzzleFlashScale>9</muzzleFlashScale>
+							</li>
+						</verbs>
+					</value>
+				</li>
 				<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
 					<defName>VWE_Gun_MakeshiftRifle</defName>
 					<statBases>
@@ -160,6 +201,7 @@
 						<SwayFactor>1.68</SwayFactor>
 						<Bulk>11.62</Bulk>
 					</statBases>
+					<!--
 					<Properties>
 						<recoilAmount>1.73</recoilAmount>
 						<verbClass>CombatExtended.Verb_ShootCE</verbClass>
@@ -173,6 +215,7 @@
 						<soundCastTail>GunTail_Medium</soundCastTail>
 						<muzzleFlashScale>9</muzzleFlashScale>
 					</Properties>
+					-->
 					<AmmoUser>
 						<magazineSize>30</magazineSize>
 						<reloadTime>4.6</reloadTime>
@@ -187,6 +230,26 @@
 						<li>CE_AI_AR</li>
 					</weaponTags>
 				</li>
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName = "VWE_Gun_MakeshiftRifle"]/verbs</xpath>
+					<value>
+						<verbs>
+							<li Class="CombatExtended.VerbPropertiesCE">
+								<recoilAmount>1.73</recoilAmount>
+								<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+								<hasStandardCommand>true</hasStandardCommand>
+								<defaultProjectile>Bullet_762x39mmSoviet_FMJ</defaultProjectile>
+								<ticksBetweenBurstShots>2</ticksBetweenBurstShots>
+								<burstShotCount>5</burstShotCount>
+								<warmupTime>1.1</warmupTime>
+								<range>44</range>
+								<soundCast>Shot_AssaultRifle</soundCast>
+								<soundCastTail>GunTail_Medium</soundCastTail>
+								<muzzleFlashScale>9</muzzleFlashScale>
+							</li>
+						</verbs>
+					</value>
+				</li>
 				<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
 					<defName>VWE_Gun_MakeshiftLMG</defName>
 					<statBases>
@@ -197,6 +260,7 @@
 						<SwayFactor>1.78</SwayFactor>
 						<Bulk>15.7</Bulk>
 					</statBases>
+					<!--
 					<Properties>
 						<recoilAmount>1.32</recoilAmount>
 						<verbClass>CombatExtended.Verb_ShootCE</verbClass>
@@ -213,6 +277,7 @@
 							<canTargetLocations>true</canTargetLocations>
 						</targetParams>
 					</Properties>
+					-->
 					<AmmoUser>
 						<magazineSize>50</magazineSize>
 						<reloadTime>5.2</reloadTime>
@@ -227,6 +292,29 @@
 						<li>CE_MachineGun</li>
 					</weaponTags>
 				</li>
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName = "VWE_Gun_MakeshiftLMG"]/verbs</xpath>
+					<value>
+						<verbs>
+							<li Class="CombatExtended.VerbPropertiesCE">
+								<recoilAmount>1.32</recoilAmount>
+								<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+								<hasStandardCommand>true</hasStandardCommand>
+								<defaultProjectile>Bullet_762x54mmR_FMJ</defaultProjectile>
+								<ticksBetweenBurstShots>7</ticksBetweenBurstShots>
+								<burstShotCount>19</burstShotCount>
+								<warmupTime>1.3</warmupTime>
+								<range>58</range>
+								<soundCast>Shot_Minigun</soundCast>
+								<soundCastTail>GunTail_Medium</soundCastTail>
+								<muzzleFlashScale>9</muzzleFlashScale>
+								<targetParams>
+									<canTargetLocations>true</canTargetLocations>
+								</targetParams>
+							</li>
+						</verbs>
+					</value>
+				</li>
 				<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
 					<defName>VWE_Gun_MakeshiftShotgun</defName>
 					<statBases>
@@ -237,6 +325,7 @@
 						<SwayFactor>1.48</SwayFactor>
 						<Bulk>9.6</Bulk>
 					</statBases>
+					<!--
 					<Properties>
 						<recoilAmount>1.69</recoilAmount>
 						<verbClass>CombatExtended.Verb_ShootCE</verbClass>
@@ -250,6 +339,7 @@
 						<soundCastTail>GunTail_Heavy</soundCastTail>
 						<muzzleFlashScale>9</muzzleFlashScale>
 					</Properties>
+					-->
 					<AmmoUser>
 						<magazineSize>2</magazineSize>
 						<reloadTime>2</reloadTime>
@@ -258,6 +348,26 @@
 					<weaponTags>
 						<li>CE_AI_BROOM</li>
 					</weaponTags>
+				</li>
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName = "VWE_Gun_MakeshiftShotgun"]/verbs</xpath>
+					<value>
+						<verbs>
+							<li Class="CombatExtended.VerbPropertiesCE">
+								<recoilAmount>1.69</recoilAmount>
+								<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+								<hasStandardCommand>true</hasStandardCommand>
+								<defaultProjectile>Bullet_12Gauge_Buck</defaultProjectile>
+								<ticksBetweenBurstShots>2</ticksBetweenBurstShots>
+								<burstShotCount>2</burstShotCount>
+								<warmupTime>0.6</warmupTime>
+								<range>14</range>
+								<soundCast>Shot_Shotgun</soundCast>
+								<soundCastTail>GunTail_Heavy</soundCastTail>
+								<muzzleFlashScale>9</muzzleFlashScale>
+							</li>
+						</verbs>
+					</value>
 				</li>
 			</operations>
 		</match>

--- a/Patches/Vanilla Weapons Expanded - Makeshift/RangedIndustrial.xml
+++ b/Patches/Vanilla Weapons Expanded - Makeshift/RangedIndustrial.xml
@@ -90,7 +90,7 @@
 						<Bulk>2.62</Bulk>
 					</statBases>
 					<Properties>
-						<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+						<verbClass>CombatExtended.Compatibility.Verb_ShootCEKEK</verbClass>
 						<hasStandardCommand>true</hasStandardCommand>
 						<defaultProjectile>Bullet_9x19mmPara_FMJ</defaultProjectile>
 						<warmupTime>0.2</warmupTime>
@@ -199,7 +199,7 @@
 					</statBases>
 					<Properties>
 						<recoilAmount>1.73</recoilAmount>
-						<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+						<verbClass>CombatExtended.Compatibility.Verb_ShootCEKEK</verbClass>
 						<hasStandardCommand>true</hasStandardCommand>
 						<defaultProjectile>Bullet_762x39mmSoviet_FMJ</defaultProjectile>
 						<ticksBetweenBurstShots>2</ticksBetweenBurstShots>
@@ -323,7 +323,7 @@
 						<hasStandardCommand>true</hasStandardCommand>
 						<defaultProjectile>Bullet_12Gauge_Buck</defaultProjectile>
 						<ticksBetweenBurstShots>2</ticksBetweenBurstShots>
-						<!--<burstShotCount>2</burstShotCount>-->
+						<burstShotCount>2</burstShotCount>
 						<warmupTime>0.6</warmupTime>
 						<range>14</range>
 						<soundCast>Shot_Shotgun</soundCast>

--- a/Patches/Vanilla Weapons Expanded - Makeshift/RangedIndustrial.xml
+++ b/Patches/Vanilla Weapons Expanded - Makeshift/RangedIndustrial.xml
@@ -1,276 +1,265 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <Patch>
-
-  <Operation Class="PatchOperationFindMod">
-    <mods>
-      <li>Vanilla Weapons Expanded - Makeshift</li>
-    </mods>
-    <match Class="PatchOperationSequence">
-      <operations>
-
-		<li Class="PatchOperationReplace">
-			<xpath>
-				/Defs/ThingDef[defName = "VWE_Gun_MakeshiftPistol"]/tools
-			</xpath>
-			<value>
-			<tools>
-				<li Class="CombatExtended.ToolCE">
-					<label>grip</label>
-					<capacities>
-						<li>Blunt</li>
-					</capacities>
-					<power>2</power>
-					<cooldownTime>1.54</cooldownTime>
-					<chanceFactor>1.5</chanceFactor>
-					<armorPenetrationBlunt>0.555</armorPenetrationBlunt>
-					<linkedBodyPartsGroup>Grip</linkedBodyPartsGroup>
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+			<li>Vanilla Weapons Expanded - Makeshift</li>
+		</mods>
+		<match Class="PatchOperationSequence">
+			<operations>
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName = "VWE_Gun_MakeshiftPistol"]/tools</xpath>
+					<value>
+						<tools>
+							<li Class="CombatExtended.ToolCE">
+								<label>grip</label>
+								<capacities>
+									<li>Blunt</li>
+								</capacities>
+								<power>2</power>
+								<cooldownTime>1.54</cooldownTime>
+								<chanceFactor>1.5</chanceFactor>
+								<armorPenetrationBlunt>0.555</armorPenetrationBlunt>
+								<linkedBodyPartsGroup>Grip</linkedBodyPartsGroup>
+							</li>
+							<li Class="CombatExtended.ToolCE">
+								<label>muzzle</label>
+								<capacities>
+									<li>Poke</li>
+								</capacities>
+								<power>2</power>
+								<cooldownTime>1.54</cooldownTime>
+								<armorPenetrationBlunt>0.555</armorPenetrationBlunt>
+								<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
+							</li>
+						</tools>
+					</value>
 				</li>
-				<li Class="CombatExtended.ToolCE">
-					<label>muzzle</label>
-					<capacities>
-						<li>Poke</li>
-					</capacities>
-					<power>2</power>
-					<cooldownTime>1.54</cooldownTime>
-					<armorPenetrationBlunt>0.555</armorPenetrationBlunt>
-					<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
+				<li Class="PatchOperationReplace">
+					<xpath>
+						Defs/ThingDef[
+							defName = "VWE_Gun_MakeshiftSMG" or
+							defName = "VWE_Gun_MakeshiftRifle" or
+							defName = "VWE_Gun_MakeshiftLMG" or
+							defName = "VWE_Gun_MakeshiftShotgun"
+						]/tools
+					</xpath>
+					<value>
+						<tools>
+							<li Class="CombatExtended.ToolCE">
+								<label>stock</label>
+								<capacities>
+									<li>Blunt</li>
+								</capacities>
+								<power>8</power>
+								<cooldownTime>1.55</cooldownTime>
+								<chanceFactor>1.5</chanceFactor>
+								<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
+								<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
+							</li>
+							<li Class="CombatExtended.ToolCE">
+								<label>barrel</label>
+								<capacities>
+									<li>Blunt</li>
+								</capacities>
+								<power>5</power>
+								<cooldownTime>2.02</cooldownTime>
+								<armorPenetrationBlunt>1.630</armorPenetrationBlunt>
+								<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
+							</li>
+							<li Class="CombatExtended.ToolCE">
+								<label>muzzle</label>
+								<capacities>
+									<li>Poke</li>
+								</capacities>
+								<power>8</power>
+								<cooldownTime>1.55</cooldownTime>
+								<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
+								<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
+							</li>
+						</tools>
+					</value>
 				</li>
-			</tools>
-			</value>
-		</li>
-
-		<li Class="PatchOperationReplace">
-			<xpath>
-				/Defs/ThingDef[
-					defName = "VWE_Gun_MakeshiftSMG" or
-					defName = "VWE_Gun_MakeshiftRifle" or
-					defName = "VWE_Gun_MakeshiftLMG" or
-					defName = "VWE_Gun_MakeshiftShotgun"
-				]/tools
-			</xpath>
-			<value>
-			<tools>
-				<li Class="CombatExtended.ToolCE">
-					<label>stock</label>
-					<capacities>
-						<li>Blunt</li>
-					</capacities>
-					<power>8</power>
-					<cooldownTime>1.55</cooldownTime>
-					<chanceFactor>1.5</chanceFactor>
-					<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-					<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
+				<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+					<defName>VWE_Gun_MakeshiftPistol</defName>
+					<statBases>
+						<Mass>1.33</Mass>
+						<RangedWeapon_Cooldown>0.42</RangedWeapon_Cooldown>
+						<SightsEfficiency>0.50</SightsEfficiency>
+						<ShotSpread>0.60</ShotSpread>
+						<SwayFactor>1.30</SwayFactor>
+						<Bulk>2.62</Bulk>
+					</statBases>
+					<Properties>
+						<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+						<hasStandardCommand>true</hasStandardCommand>
+						<defaultProjectile>Bullet_9x19mmPara_FMJ</defaultProjectile>
+						<warmupTime>0.2</warmupTime>
+						<range>10</range>
+						<soundCast>Shot_Autopistol</soundCast>
+						<soundCastTail>GunTail_Light</soundCastTail>
+						<muzzleFlashScale>9</muzzleFlashScale>
+					</Properties>
+					<AmmoUser>
+						<magazineSize>5</magazineSize>
+						<reloadTime>4</reloadTime>
+						<ammoSet>AmmoSet_9x19mmPara</ammoSet>
+					</AmmoUser>
+					<FireModes>
+						<aiUseBurstMode>FALSE</aiUseBurstMode>
+						<aiAimMode>Snapshot</aiAimMode>
+					</FireModes>
+					<weaponTags>
+						<li>CE_AI_Pistol</li>
+						<li>CE_OneHandedWeapon</li>
+					</weaponTags>
 				</li>
-				<li Class="CombatExtended.ToolCE">
-					<label>barrel</label>
-					<capacities>
-						<li>Blunt</li>
-					</capacities>
-					<power>5</power>
-					<cooldownTime>2.02</cooldownTime>
-					<armorPenetrationBlunt>1.630</armorPenetrationBlunt>
-					<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
+				<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+					<defName>VWE_Gun_MakeshiftSMG</defName>
+					<statBases>
+						<Mass>2.83</Mass>
+						<RangedWeapon_Cooldown>0.40</RangedWeapon_Cooldown>
+						<SightsEfficiency>0.80</SightsEfficiency>
+						<ShotSpread>0.38</ShotSpread>
+						<SwayFactor>1.18</SwayFactor>
+						<Bulk>5.62</Bulk>
+					</statBases>
+					<Properties>
+						<recoilAmount>2.02</recoilAmount>
+						<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+						<hasStandardCommand>true</hasStandardCommand>
+						<defaultProjectile>Bullet_9x19mmPara_FMJ</defaultProjectile>
+						<ticksBetweenBurstShots>2</ticksBetweenBurstShots>
+						<burstShotCount>6</burstShotCount>
+						<warmupTime>0.6</warmupTime>
+						<range>22</range>
+						<soundCast>Shot_MachinePistol</soundCast>
+						<soundCastTail>GunTail_Light</soundCastTail>
+						<muzzleFlashScale>9</muzzleFlashScale>
+					</Properties>
+					<AmmoUser>
+						<magazineSize>24</magazineSize>
+						<reloadTime>4.4</reloadTime>
+						<ammoSet>AmmoSet_9x19mmPara</ammoSet>
+					</AmmoUser>
+					<FireModes>
+						<aiUseBurstMode>FALSE</aiUseBurstMode>
+						<aiAimMode>SuppressFire</aiAimMode>
+						<aimedBurstShotCount>4</aimedBurstShotCount>
+					</FireModes>
+					<weaponTags>
+						<li>CE_MachineGun</li>
+					</weaponTags>
 				</li>
-				<li Class="CombatExtended.ToolCE">
-					<label>muzzle</label>
-					<capacities>
-						<li>Poke</li>
-					</capacities>
-					<power>8</power>
-					<cooldownTime>1.55</cooldownTime>
-					<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-					<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
+				<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+					<defName>VWE_Gun_MakeshiftRifle</defName>
+					<statBases>
+						<Mass>4</Mass>
+						<RangedWeapon_Cooldown>0.40</RangedWeapon_Cooldown>
+						<SightsEfficiency>0.80</SightsEfficiency>
+						<ShotSpread>0.30</ShotSpread>
+						<SwayFactor>1.68</SwayFactor>
+						<Bulk>11.62</Bulk>
+					</statBases>
+					<Properties>
+						<recoilAmount>1.73</recoilAmount>
+						<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+						<hasStandardCommand>true</hasStandardCommand>
+						<defaultProjectile>Bullet_762x39mmSoviet_FMJ</defaultProjectile>
+						<ticksBetweenBurstShots>2</ticksBetweenBurstShots>
+						<burstShotCount>5</burstShotCount>
+						<warmupTime>1.1</warmupTime>
+						<range>44</range>
+						<soundCast>Shot_AssaultRifle</soundCast>
+						<soundCastTail>GunTail_Medium</soundCastTail>
+						<muzzleFlashScale>9</muzzleFlashScale>
+					</Properties>
+					<AmmoUser>
+						<magazineSize>30</magazineSize>
+						<reloadTime>4.6</reloadTime>
+						<ammoSet>AmmoSet_762x39mmSoviet</ammoSet>
+					</AmmoUser>
+					<FireModes>
+						<aiUseBurstMode>FALSE</aiUseBurstMode>
+						<aiAimMode>SuppressFire</aiAimMode>
+						<aimedBurstShotCount>4</aimedBurstShotCount>
+					</FireModes>
+					<weaponTags>
+						<li>CE_AI_AR</li>
+					</weaponTags>
 				</li>
-			</tools>
-			</value>
-		</li>
-
-		<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
-			<defName>VWE_Gun_MakeshiftPistol</defName>
-			<statBases>
-				<Mass>1.33</Mass>
-				<RangedWeapon_Cooldown>0.42</RangedWeapon_Cooldown>
-				<SightsEfficiency>0.50</SightsEfficiency>
-				<ShotSpread>0.60</ShotSpread>
-				<SwayFactor>1.30</SwayFactor>
-				<Bulk>2.62</Bulk>
-			</statBases>
-			<Properties>
-				<verbClass>CombatExtended.Verb_ShootCE</verbClass>
-				<hasStandardCommand>true</hasStandardCommand>
-				<defaultProjectile>Bullet_9x19mmPara_FMJ</defaultProjectile>
-				<warmupTime>0.2</warmupTime>
-				<range>10</range>
-				<soundCast>Shot_Autopistol</soundCast>
-				<soundCastTail>GunTail_Light</soundCastTail>
-				<muzzleFlashScale>9</muzzleFlashScale>
-			</Properties>
-			<AmmoUser>
-				<magazineSize>5</magazineSize>
-				<reloadTime>4</reloadTime>
-				<ammoSet>AmmoSet_9x19mmPara</ammoSet>
-			</AmmoUser>
-			<FireModes>
-				<aiUseBurstMode>FALSE</aiUseBurstMode>
-				<aiAimMode>Snapshot</aiAimMode>
-			</FireModes>
-			<weaponTags>
-				<li>CE_AI_Pistol</li>
-				<li>CE_OneHandedWeapon</li>
-			</weaponTags>
-		</li>
-
-		<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
-			<defName>VWE_Gun_MakeshiftSMG</defName>
-			<statBases>
-				<Mass>2.83</Mass>
-				<RangedWeapon_Cooldown>0.40</RangedWeapon_Cooldown>
-				<SightsEfficiency>0.80</SightsEfficiency>
-				<ShotSpread>0.38</ShotSpread>
-				<SwayFactor>1.18</SwayFactor>
-				<Bulk>5.62</Bulk>
-			</statBases>
-			<Properties>
-				<recoilAmount>2.02</recoilAmount>
-				<verbClass>CombatExtended.Verb_ShootCE</verbClass>
-				<hasStandardCommand>true</hasStandardCommand>
-				<defaultProjectile>Bullet_9x19mmPara_FMJ</defaultProjectile>
-				<ticksBetweenBurstShots>2</ticksBetweenBurstShots>
-				<burstShotCount>6</burstShotCount>
-				<warmupTime>0.6</warmupTime>
-				<range>22</range>
-				<soundCast>Shot_MachinePistol</soundCast>
-				<soundCastTail>GunTail_Light</soundCastTail>
-				<muzzleFlashScale>9</muzzleFlashScale>
-			</Properties>
-			<AmmoUser>
-				<magazineSize>24</magazineSize>
-				<reloadTime>4.4</reloadTime>
-				<ammoSet>AmmoSet_9x19mmPara</ammoSet>
-			</AmmoUser>
-			<FireModes>
-				<aiUseBurstMode>FALSE</aiUseBurstMode>
-				<aiAimMode>SuppressFire</aiAimMode>
-				<aimedBurstShotCount>4</aimedBurstShotCount>
-			</FireModes>
-			<weaponTags>
-				<li>CE_MachineGun</li>
-			</weaponTags>
-		</li>
-
-		<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
-			<defName>VWE_Gun_MakeshiftRifle</defName>
-			<statBases>
-				<Mass>4</Mass>
-				<RangedWeapon_Cooldown>0.40</RangedWeapon_Cooldown>
-				<SightsEfficiency>0.80</SightsEfficiency>
-				<ShotSpread>0.30</ShotSpread>
-				<SwayFactor>1.68</SwayFactor>
-				<Bulk>11.62</Bulk>
-			</statBases>
-			<Properties>
-				<recoilAmount>1.73</recoilAmount>
-				<verbClass>CombatExtended.Verb_ShootCE</verbClass>
-				<hasStandardCommand>true</hasStandardCommand>
-				<defaultProjectile>Bullet_762x39mmSoviet_FMJ</defaultProjectile>
-				<ticksBetweenBurstShots>2</ticksBetweenBurstShots>
-				<burstShotCount>5</burstShotCount>
-				<warmupTime>1.1</warmupTime>
-				<range>44</range>
-				<soundCast>Shot_AssaultRifle</soundCast>
-				<soundCastTail>GunTail_Medium</soundCastTail>
-				<muzzleFlashScale>9</muzzleFlashScale>
-			</Properties>
-			<AmmoUser>
-				<magazineSize>30</magazineSize>
-				<reloadTime>4.6</reloadTime>
-				<ammoSet>AmmoSet_762x39mmSoviet</ammoSet>
-			</AmmoUser>
-			<FireModes>
-				<aiUseBurstMode>FALSE</aiUseBurstMode>
-				<aiAimMode>SuppressFire</aiAimMode>
-				<aimedBurstShotCount>4</aimedBurstShotCount>
-			</FireModes>
-			<weaponTags>
-				<li>CE_AI_AR</li>
-			</weaponTags>
-		</li>
-
-		<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
-			<defName>VWE_Gun_MakeshiftLMG</defName>
-			<statBases>
-				<Mass>11.5</Mass>
-				<RangedWeapon_Cooldown>0.56</RangedWeapon_Cooldown>
-				<SightsEfficiency>0.80</SightsEfficiency>
-				<ShotSpread>0.28</ShotSpread>
-				<SwayFactor>1.78</SwayFactor>
-				<Bulk>15.7</Bulk>
-			</statBases>
-			<Properties>
-				<recoilAmount>1.32</recoilAmount>
-				<verbClass>CombatExtended.Verb_ShootCE</verbClass>
-				<hasStandardCommand>true</hasStandardCommand>
-				<defaultProjectile>Bullet_762x54mmR_FMJ</defaultProjectile>
-				<ticksBetweenBurstShots>7</ticksBetweenBurstShots>
-				<burstShotCount>19</burstShotCount>
-				<warmupTime>1.3</warmupTime>
-				<range>58</range>
-				<soundCast>Shot_Minigun</soundCast>
-				<soundCastTail>GunTail_Medium</soundCastTail>
-				<muzzleFlashScale>9</muzzleFlashScale>
-				<targetParams>
-					<canTargetLocations>true</canTargetLocations>
-				</targetParams>				
-			</Properties>
-			<AmmoUser>
-				<magazineSize>50</magazineSize>
-				<reloadTime>5.2</reloadTime>
-				<ammoSet>AmmoSet_762x54mmR</ammoSet>
-			</AmmoUser>
-			<FireModes>
-				<aiUseBurstMode>FALSE</aiUseBurstMode>
-				<aiAimMode>SuppressFire</aiAimMode>
-				<aimedBurstShotCount>19</aimedBurstShotCount>
-			</FireModes>
-			<weaponTags>
-				<li>CE_MachineGun</li>
-			</weaponTags>
-		</li>
-
-		<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
-			<defName>VWE_Gun_MakeshiftShotgun</defName>
-			<statBases>
-				<Mass>4.5</Mass>
-				<RangedWeapon_Cooldown>1.0</RangedWeapon_Cooldown>
-				<SightsEfficiency>0.80</SightsEfficiency>
-				<ShotSpread>0.38</ShotSpread>
-				<SwayFactor>1.48</SwayFactor>
-				<Bulk>9.6</Bulk>
-			</statBases>
-			<Properties>
-				<recoilAmount>1.69</recoilAmount>
-				<verbClass>CombatExtended.Verb_ShootCE</verbClass>
-				<hasStandardCommand>true</hasStandardCommand>
-				<defaultProjectile>Bullet_12Gauge_Buck</defaultProjectile>
-				<ticksBetweenBurstShots>2</ticksBetweenBurstShots>
-				<burstShotCount>2</burstShotCount>
-				<warmupTime>0.6</warmupTime>
-				<range>14</range>
-				<soundCast>Shot_Shotgun</soundCast>
-				<soundCastTail>GunTail_Heavy</soundCastTail>
-				<muzzleFlashScale>9</muzzleFlashScale>
-			</Properties>
-			<AmmoUser>
-				<magazineSize>2</magazineSize>
-				<reloadTime>2</reloadTime>
-				<ammoSet>AmmoSet_12Gauge</ammoSet>
-			</AmmoUser>
-			<weaponTags>
-				<li>CE_AI_BROOM</li>
-			</weaponTags>
-		</li>
-
-      </operations>
-    </match>
-  </Operation>
+				<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+					<defName>VWE_Gun_MakeshiftLMG</defName>
+					<statBases>
+						<Mass>11.5</Mass>
+						<RangedWeapon_Cooldown>0.56</RangedWeapon_Cooldown>
+						<SightsEfficiency>0.80</SightsEfficiency>
+						<ShotSpread>0.28</ShotSpread>
+						<SwayFactor>1.78</SwayFactor>
+						<Bulk>15.7</Bulk>
+					</statBases>
+					<Properties>
+						<recoilAmount>1.32</recoilAmount>
+						<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+						<hasStandardCommand>true</hasStandardCommand>
+						<defaultProjectile>Bullet_762x54mmR_FMJ</defaultProjectile>
+						<ticksBetweenBurstShots>7</ticksBetweenBurstShots>
+						<burstShotCount>19</burstShotCount>
+						<warmupTime>1.3</warmupTime>
+						<range>58</range>
+						<soundCast>Shot_Minigun</soundCast>
+						<soundCastTail>GunTail_Medium</soundCastTail>
+						<muzzleFlashScale>9</muzzleFlashScale>
+						<targetParams>
+							<canTargetLocations>true</canTargetLocations>
+						</targetParams>
+					</Properties>
+					<AmmoUser>
+						<magazineSize>50</magazineSize>
+						<reloadTime>5.2</reloadTime>
+						<ammoSet>AmmoSet_762x54mmR</ammoSet>
+					</AmmoUser>
+					<FireModes>
+						<aiUseBurstMode>FALSE</aiUseBurstMode>
+						<aiAimMode>SuppressFire</aiAimMode>
+						<aimedBurstShotCount>19</aimedBurstShotCount>
+					</FireModes>
+					<weaponTags>
+						<li>CE_MachineGun</li>
+					</weaponTags>
+				</li>
+				<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+					<defName>VWE_Gun_MakeshiftShotgun</defName>
+					<statBases>
+						<Mass>4.5</Mass>
+						<RangedWeapon_Cooldown>1.0</RangedWeapon_Cooldown>
+						<SightsEfficiency>0.80</SightsEfficiency>
+						<ShotSpread>0.38</ShotSpread>
+						<SwayFactor>1.48</SwayFactor>
+						<Bulk>9.6</Bulk>
+					</statBases>
+					<Properties>
+						<recoilAmount>1.69</recoilAmount>
+						<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+						<hasStandardCommand>true</hasStandardCommand>
+						<defaultProjectile>Bullet_12Gauge_Buck</defaultProjectile>
+						<ticksBetweenBurstShots>2</ticksBetweenBurstShots>
+						<burstShotCount>2</burstShotCount>
+						<warmupTime>0.6</warmupTime>
+						<range>14</range>
+						<soundCast>Shot_Shotgun</soundCast>
+						<soundCastTail>GunTail_Heavy</soundCastTail>
+						<muzzleFlashScale>9</muzzleFlashScale>
+					</Properties>
+					<AmmoUser>
+						<magazineSize>2</magazineSize>
+						<reloadTime>2</reloadTime>
+						<ammoSet>AmmoSet_12Gauge</ammoSet>
+					</AmmoUser>
+					<weaponTags>
+						<li>CE_AI_BROOM</li>
+					</weaponTags>
+				</li>
+			</operations>
+		</match>
+	</Operation>
 </Patch>  

--- a/Source/CombatExtended/CombatExtended/PatchOperationMakeGunCECompatible.cs
+++ b/Source/CombatExtended/CombatExtended/PatchOperationMakeGunCECompatible.cs
@@ -182,6 +182,10 @@ namespace CombatExtended
             {
                 // remove Verb_Shoot
                 var verb_shoot_nodes = verbs.SelectNodes("li[verbClass=\"Verb_Shoot\" or verbClass=\"Verb_ShootOneUse\" or verbClass=\"Verb_LaunchProjectile\"]");
+                if (ModLister.HasActiveModWithName("Vanilla Weapons Expanded - Makeshift"))
+                {
+                    verb_shoot_nodes = verbs.SelectNodes("li[verbClass=\"Verb_Shoot\" or verbClass=\"Verb_ShootOneUse\" or verbClass=\"Verb_LaunchProjectile\" or verbClass=\"VWEMakeshift.Verb_MakeshiftShoot\"]");
+                }
                 foreach (var verb_shoot_current in verb_shoot_nodes)
                 {
                     var verb_shoot = verb_shoot_current as XmlNode;

--- a/Source/CombatExtended/CombatExtended/PatchOperationMakeGunCECompatible.cs
+++ b/Source/CombatExtended/CombatExtended/PatchOperationMakeGunCECompatible.cs
@@ -182,10 +182,6 @@ namespace CombatExtended
             {
                 // remove Verb_Shoot
                 var verb_shoot_nodes = verbs.SelectNodes("li[verbClass=\"Verb_Shoot\" or verbClass=\"Verb_ShootOneUse\" or verbClass=\"Verb_LaunchProjectile\" or verbClass=\"VWEMakeshift.Verb_MakeshiftShoot\"]");
-                /*if (ModLister.HasActiveModWithName("Vanilla Weapons Expanded - Makeshift"))
-                {
-                    verb_shoot_nodes = verbs.SelectNodes("li[verbClass=\"Verb_Shoot\" or verbClass=\"Verb_ShootOneUse\" or verbClass=\"Verb_LaunchProjectile\" or verbClass=\"VWEMakeshift.Verb_MakeshiftShoot\"]");
-                }*/
                 foreach (var verb_shoot_current in verb_shoot_nodes)
                 {
                     var verb_shoot = verb_shoot_current as XmlNode;

--- a/Source/CombatExtended/CombatExtended/PatchOperationMakeGunCECompatible.cs
+++ b/Source/CombatExtended/CombatExtended/PatchOperationMakeGunCECompatible.cs
@@ -181,11 +181,11 @@ namespace CombatExtended
             if (GetOrCreateNode(xml, xmlNode, "verbs", out verbs))
             {
                 // remove Verb_Shoot
-                var verb_shoot_nodes = verbs.SelectNodes("li[verbClass=\"Verb_Shoot\" or verbClass=\"Verb_ShootOneUse\" or verbClass=\"Verb_LaunchProjectile\"]");
-                if (ModLister.HasActiveModWithName("Vanilla Weapons Expanded - Makeshift"))
+                var verb_shoot_nodes = verbs.SelectNodes("li[verbClass=\"Verb_Shoot\" or verbClass=\"Verb_ShootOneUse\" or verbClass=\"Verb_LaunchProjectile\" or verbClass=\"VWEMakeshift.Verb_MakeshiftShoot\"]");
+                /*if (ModLister.HasActiveModWithName("Vanilla Weapons Expanded - Makeshift"))
                 {
                     verb_shoot_nodes = verbs.SelectNodes("li[verbClass=\"Verb_Shoot\" or verbClass=\"Verb_ShootOneUse\" or verbClass=\"Verb_LaunchProjectile\" or verbClass=\"VWEMakeshift.Verb_MakeshiftShoot\"]");
-                }
+                }*/
                 foreach (var verb_shoot_current in verb_shoot_nodes)
                 {
                     var verb_shoot = verb_shoot_current as XmlNode;

--- a/Source/CombatExtended/CombatExtended/PatchOperationMakeGunCECompatible.cs
+++ b/Source/CombatExtended/CombatExtended/PatchOperationMakeGunCECompatible.cs
@@ -181,7 +181,12 @@ namespace CombatExtended
             if (GetOrCreateNode(xml, xmlNode, "verbs", out verbs))
             {
                 // remove Verb_Shoot
-                var verb_shoot_nodes = verbs.SelectNodes("li[verbClass=\"Verb_Shoot\" or verbClass=\"Verb_ShootOneUse\" or verbClass=\"Verb_LaunchProjectile\" or verbClass=\"VWEMakeshift.Verb_MakeshiftShoot\"]");
+                var verb_shoot_nodes = verbs.SelectNodes(
+                    "li[verbClass=\"Verb_Shoot\" or " +
+                    "verbClass=\"Verb_ShootOneUse\" or " +
+                    "verbClass=\"Verb_LaunchProjectile\" or " +
+                    "verbClass=\"VWEMakeshift.Verb_MakeshiftShoot\"]");
+
                 foreach (var verb_shoot_current in verb_shoot_nodes)
                 {
                     var verb_shoot = verb_shoot_current as XmlNode;

--- a/Source/CombatExtended/Compatibility/VWEPatch.cs
+++ b/Source/CombatExtended/Compatibility/VWEPatch.cs
@@ -1,93 +1,79 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using RimWorld;
+﻿using RimWorld;
+using System;
 using Verse;
-using Verse.AI;
-using CombatExtended;
-using UnityEngine;
-using Verse.Sound;
 
 namespace CombatExtended.Compatibility
 {
     public class Verb_ShootCEKEK : Verb_ShootCE
     {
-	public override int ShotsPerBurstFor(FireMode mode)
-	{
-	    if (base.CompFireModes != null)
-	    {
-		if (mode == FireMode.SingleFire)
-		{
+        public override int ShotsPerBurstFor(FireMode mode)
+        {
+            if (base.CompFireModes != null)
+            {
+                if (mode == FireMode.SingleFire)
+                {
 
-		    int lint = Rand.Range(0, 2);
-		    if (lint != 0)
-		    {
-			return lint;
-		    }
-			
-		    if (Rand.Range(0, 1000) == 1000)
-		    {
-			GenExplosionCE.DoExplosion(caster.Position, caster.Map, 2f, DamageDefOf.Bomb, null, 5, 0f, SoundDefOf.Psycast_Skip_Exit, null, null, null, null, 0, 0, null, true, null, 0f, 0, 0f, false);
-		    }
-		    return 0;
-			
+                    int lint = Rand.Range(0, 2);
+                    if (lint != 0)
+                    {
+                        return lint;
+                    }
 
-		}
-		if (mode == FireMode.BurstFire)
-		{
-		    return Rand.Range(0, base.CompFireModes.Props.aimedBurstShotCount + 1);
-		}
-	    }
-	    return Rand.Range(0, base.VerbPropsCE.burstShotCount + 1);
-	    
-	}
+                    if (Rand.Range(0, 1000) == 1000)
+                    {
+                        GenExplosionCE.DoExplosion(caster.Position, caster.Map, 2f, DamageDefOf.Bomb, null, 5, 0f, SoundDefOf.Psycast_Skip_Exit, null, null, null, null, 0, 0, null, true, null, 0f, 0, 0f, false);
+                    }
+                    return 0;
+
+                }
+                if (mode == FireMode.BurstFire)
+                {
+                    return Rand.Range(0, base.CompFireModes.Props.aimedBurstShotCount + 1);
+                }
+            }
+            return Rand.Range(0, base.VerbPropsCE.burstShotCount + 1);
+        }
     }
     public class RandomDamage : ThingComp
     {
-	public int max_damage  => Props.max_damage;
-	public int Pellets => Props.pelletsMax;
-	public int pletts => Props.pelletsMin;
-		
-	public RandDamageProps Props => (RandDamageProps)this.props;
-	public override void Initialize(CompProperties props)
-	{
-	    AmmoDef me = parent.def as AmmoDef;
-	    ProjectilePropertiesCE nomo = me.projectile as ProjectilePropertiesCE;
-	    nomo.speed = Rand.Range(50, 200);
-			
-	    //Log.Error(nomo.pelletCount.ToString());
-	    //nomo.armorPenetrationSharp
-			
-			
-			
-	    base.Initialize(props);
-	}
-	public override void CompTick()
-	{
-	    AmmoDef me = parent.def as AmmoDef;
-	    ProjectilePropertiesCE nomo = me.projectile as ProjectilePropertiesCE;
-	    nomo.pelletCount = Rand.Range(pletts, Pellets);
-	    //Log.Error(nomo.pelletCount.ToString());
-	}
-		
+        public int max_damage => Props.max_damage;
+        public int Pellets => Props.pelletsMax;
+        public int pletts => Props.pelletsMin;
 
+        public RandDamageProps Props => (RandDamageProps)this.props;
+        public override void Initialize(CompProperties props)
+        {
+            AmmoDef me = parent.def as AmmoDef;
+            ProjectilePropertiesCE nomo = me.projectile as ProjectilePropertiesCE;
+            nomo.speed = Rand.Range(50, 200);
+
+            //Log.Error(nomo.pelletCount.ToString());
+            //nomo.armorPenetrationSharp
+
+            base.Initialize(props);
+        }
+        public override void CompTick()
+        {
+            AmmoDef me = parent.def as AmmoDef;
+            ProjectilePropertiesCE nomo = me.projectile as ProjectilePropertiesCE;
+            nomo.pelletCount = Rand.Range(pletts, Pellets);
+            //Log.Error(nomo.pelletCount.ToString());
+        }
     }
-   
+
     public class RandDamageProps : CompProperties
     {
-	public int pelletsMax;
-	public int max_damage;
-	public int pelletsMin;
-	public RandDamageProps()
-	{
-	    this.compClass = typeof(RandomDamage);
-	}
+        public int pelletsMax;
+        public int max_damage;
+        public int pelletsMin;
+        public RandDamageProps()
+        {
+            this.compClass = typeof(RandomDamage);
+        }
 
-	public RandDamageProps(Type compClass) : base(compClass)
-	{
-	    this.compClass = compClass;
-	}
+        public RandDamageProps(Type compClass) : base(compClass)
+        {
+            this.compClass = compClass;
+        }
     }
 }

--- a/Source/CombatExtended/Compatibility/VWEPatch.cs
+++ b/Source/CombatExtended/Compatibility/VWEPatch.cs
@@ -1,0 +1,93 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using RimWorld;
+using Verse;
+using Verse.AI;
+using CombatExtended;
+using UnityEngine;
+using Verse.Sound;
+
+namespace CombatExtended.Compatibility
+{
+    public class Verb_ShootCEKEK : Verb_ShootCE
+    {
+	public override int ShotsPerBurstFor(FireMode mode)
+	{
+	    if (base.CompFireModes != null)
+	    {
+		if (mode == FireMode.SingleFire)
+		{
+
+		    int lint = Rand.Range(0, 2);
+		    if (lint != 0)
+		    {
+			return lint;
+		    }
+			
+		    if (Rand.Range(0, 1000) == 1000)
+		    {
+			GenExplosionCE.DoExplosion(caster.Position, caster.Map, 2f, DamageDefOf.Bomb, null, 5, 0f, SoundDefOf.Psycast_Skip_Exit, null, null, null, null, 0, 0, null, true, null, 0f, 0, 0f, false);
+		    }
+		    return 0;
+			
+
+		}
+		if (mode == FireMode.BurstFire)
+		{
+		    return Rand.Range(0, base.CompFireModes.Props.aimedBurstShotCount + 1);
+		}
+	    }
+	    return Rand.Range(0, base.VerbPropsCE.burstShotCount + 1);
+	    
+	}
+    }
+    public class RandomDamage : ThingComp
+    {
+	public int max_damage  => Props.max_damage;
+	public int Pellets => Props.pelletsMax;
+	public int pletts => Props.pelletsMin;
+		
+	public RandDamageProps Props => (RandDamageProps)this.props;
+	public override void Initialize(CompProperties props)
+	{
+	    AmmoDef me = parent.def as AmmoDef;
+	    ProjectilePropertiesCE nomo = me.projectile as ProjectilePropertiesCE;
+	    nomo.speed = Rand.Range(50, 200);
+			
+	    //Log.Error(nomo.pelletCount.ToString());
+	    //nomo.armorPenetrationSharp
+			
+			
+			
+	    base.Initialize(props);
+	}
+	public override void CompTick()
+	{
+	    AmmoDef me = parent.def as AmmoDef;
+	    ProjectilePropertiesCE nomo = me.projectile as ProjectilePropertiesCE;
+	    nomo.pelletCount = Rand.Range(pletts, Pellets);
+	    //Log.Error(nomo.pelletCount.ToString());
+	}
+		
+
+    }
+   
+    public class RandDamageProps : CompProperties
+    {
+	public int pelletsMax;
+	public int max_damage;
+	public int pelletsMin;
+	public RandDamageProps()
+	{
+	    this.compClass = typeof(RandomDamage);
+	}
+
+	public RandDamageProps(Type compClass) : base(compClass)
+	{
+	    this.compClass = compClass;
+	}
+    }
+}


### PR DESCRIPTION
## Additions

Describe new functionality added by your code, e.g.
- Tribal smoke bombs
- New tribal smoke bomb sprite
- Tribal smoke bomb recipes at smithing bench and crafting spot using prometheum

## Changes

Describe adjustments to existing features made in this merge, e.g.
- Increased regular smoke bomb radius

## References

Links to the associated issues or other related pull requests, e.g.
- Closes #[ISSUE_NUMBER]
- Contributes towards #[ISSUE_NUMBER]

## Reasoning

Why did you choose to implement things this way, e.g.
- Tribals need ways to close distance with pirate raiders
- Smoke bombs allow this while enhancing combat micro
- Thematically appropriate as we already allow tribal prometheum handling
- Easy to implement
- Buffed regular smoke grenades as they are rarely utilized and to justify additional investment

## Alternatives

Describe alternative implementations you have considered, e.g.
- Tribal catapult that launches melee animals into siege camps:
  - Additional use for animals
  - Anachronistic
  - Breaks realism theme

## Testing

Check tests you have performed:
- [ ] Compiles without warnings
- [ ] Game runs without errors
- [ ] (For compatibility patches) ...with and without patched mod loaded
- [ ] Playtested a colony (specify how long)
