### PR TITLE
Samael gray worn bulk stuff

### DIFF
--- a/Biotech/Patches/ThingDefs_Misc/Weapons/RangedMechanoid_Light.xml
+++ b/Biotech/Patches/ThingDefs_Misc/Weapons/RangedMechanoid_Light.xml
@@ -70,7 +70,7 @@
       <warmupTime>0.8</warmupTime>
       <range>14</range>
       <soundCast>Shot_Shotgun_NoRack</soundCast>
-      <soundCastTail>GunTail_Nedium</soundCastTail>
+      <soundCastTail>GunTail_Medium</soundCastTail>
       <muzzleFlashScale>6</muzzleFlashScale>
     </Properties>
     <AmmoUser>

--- a/Defs/Stats/Stats_Apparel.xml
+++ b/Defs/Stats/Stats_Apparel.xml
@@ -20,10 +20,10 @@
         <factorAwful>1.25</factorAwful>
         <factorPoor>1.1</factorPoor>
         <factorNormal>1</factorNormal>
-        <factorGood>1</factorGood>
-        <factorExcellent>0.95</factorExcellent>
-        <factorMasterwork>0.90</factorMasterwork>
-        <factorLegendary>0.80</factorLegendary>
+        <factorGood>0.95</factorGood>
+        <factorExcellent>0.90</factorExcellent>
+        <factorMasterwork>0.85</factorMasterwork>
+        <factorLegendary>0.75</factorLegendary>
       </li>
     </parts>
   </StatDef>

--- a/Defs/Stats/Stats_Apparel.xml
+++ b/Defs/Stats/Stats_Apparel.xml
@@ -16,6 +16,15 @@
         <stuffPowerStat>WornBulk</stuffPowerStat>
         <multiplierStat>StuffEffectMultiplierArmor</multiplierStat>
       </li>
+      <li Class="StatPart_Quality">
+        <factorAwful>1.25</factorAwful>
+        <factorPoor>1.1</factorPoor>
+        <factorNormal>1</factorNormal>
+        <factorGood>1</factorGood>
+        <factorExcellent>0.95</factorExcellent>
+        <factorMasterwork>0.90</factorMasterwork>
+        <factorLegendary>0.80</factorLegendary>
+      </li>
     </parts>
   </StatDef>
 
@@ -43,6 +52,5 @@
     <toStringStyle>PercentZero</toStringStyle>
     <showIfUndefined>false</showIfUndefined>
   </StatDef>  
-
 
 </Defs>

--- a/Defs/Stats/Stats_Apparel.xml
+++ b/Defs/Stats/Stats_Apparel.xml
@@ -18,7 +18,7 @@
       </li>
       <li Class="StatPart_Quality">
         <factorAwful>1.2</factorAwful>
-        <factorPoor>1.1</factorPoor>
+        <factorPoor>1.05</factorPoor>
         <factorNormal>1</factorNormal>
         <factorGood>1.0</factorGood>
         <factorExcellent>0.95</factorExcellent>

--- a/Defs/Stats/Stats_Apparel.xml
+++ b/Defs/Stats/Stats_Apparel.xml
@@ -17,13 +17,13 @@
         <multiplierStat>StuffEffectMultiplierArmor</multiplierStat>
       </li>
       <li Class="StatPart_Quality">
-        <factorAwful>1.25</factorAwful>
+        <factorAwful>1.2</factorAwful>
         <factorPoor>1.1</factorPoor>
         <factorNormal>1</factorNormal>
-        <factorGood>0.95</factorGood>
-        <factorExcellent>0.90</factorExcellent>
-        <factorMasterwork>0.85</factorMasterwork>
-        <factorLegendary>0.75</factorLegendary>
+        <factorGood>1.0</factorGood>
+        <factorExcellent>0.95</factorExcellent>
+        <factorMasterwork>0.9</factorMasterwork>
+        <factorLegendary>0.8</factorLegendary>
       </li>
     </parts>
   </StatDef>


### PR DESCRIPTION
## Additions

Describe new functionality added by your code, e.g.
- Tribal smoke bombs
- New tribal smoke bomb sprite
- Tribal smoke bomb recipes at smithing bench and crafting spot using prometheum

## Changes

Describe adjustments to existing features made in this merge, e.g.
- Increased regular smoke bomb radius

## References

Links to the associated issues or other related pull requests, e.g.
- Closes #[ISSUE_NUMBER]
- Contributes towards #[ISSUE_NUMBER]

## Reasoning

Why did you choose to implement things this way, e.g.
- Tribals need ways to close distance with pirate raiders
- Smoke bombs allow this while enhancing combat micro
- Thematically appropriate as we already allow tribal prometheum handling
- Easy to implement
- Buffed regular smoke grenades as they are rarely utilized and to justify additional investment

## Alternatives

Describe alternative implementations you have considered, e.g.
- Tribal catapult that launches melee animals into siege camps:
  - Additional use for animals
  - Anachronistic
  - Breaks realism theme

## Testing

Check tests you have performed:
- [ ] Compiles without warnings
- [ ] Game runs without errors
- [ ] (For compatibility patches) ...with and without patched mod loaded
- [ ] Playtested a colony (specify how long)
