### PR TITLE
Fix #2069

### DIFF
--- a/Source/CombatExtended/Harmony/Harmony_CompAbilityEffect_LaunchProjectile.cs
+++ b/Source/CombatExtended/Harmony/Harmony_CompAbilityEffect_LaunchProjectile.cs
@@ -28,13 +28,14 @@ namespace CombatExtended.HarmonyCE
                     var sourceLoc = new Vector2();
                     sourceLoc.Set(u.x, u.z);
                     var targetLocation = new Vector2();
-                    targetLocation.Set(target.Pawn.TrueCenter().x, target.Pawn.TrueCenter().z);
+                    targetLocation.Set(target.Thing.TrueCenter().x, target.Thing.TrueCenter().z);
 
                     var w = (targetLocation - sourceLoc);
                     float shotRotation = (-90 + Mathf.Rad2Deg * Mathf.Atan2(w.y, w.x)) % 360;
 
-                    var angle = ProjectileCE.GetShotAngle(projectileDef.projectile.speed, (target.Cell - pawn.Position).LengthHorizontal, 0, false, ppce.Gravity);
-                    CE_Utility.LaunchProjectileCE(projectileDef, sourceLoc, target, pawn, angle, shotRotation, 1, 80);
+                    var targetVert = new CollisionVertical(target.Thing);
+                    var angle = ProjectileCE.GetShotAngle(ppce.speed, (target.Cell - pawn.Position).LengthHorizontal, targetVert.HeightRange.Average - 1, ppce.flyOverhead, ppce.Gravity);
+                    CE_Utility.LaunchProjectileCE(projectileDef, sourceLoc, target, pawn, angle, shotRotation, 1, ppce.speed);
                     return false;
                 }
             }


### PR DESCRIPTION
## Additions

Describe new functionality added by your code, e.g.
- Tribal smoke bombs
- New tribal smoke bomb sprite
- Tribal smoke bomb recipes at smithing bench and crafting spot using prometheum

## Changes

Describe adjustments to existing features made in this merge, e.g.
- Increased regular smoke bomb radius

## References

Links to the associated issues or other related pull requests, e.g.
- Closes #[ISSUE_NUMBER]
- Contributes towards #[ISSUE_NUMBER]

## Reasoning

Why did you choose to implement things this way, e.g.
- Tribals need ways to close distance with pirate raiders
- Smoke bombs allow this while enhancing combat micro
- Thematically appropriate as we already allow tribal prometheum handling
- Easy to implement
- Buffed regular smoke grenades as they are rarely utilized and to justify additional investment

## Alternatives

Describe alternative implementations you have considered, e.g.
- Tribal catapult that launches melee animals into siege camps:
  - Additional use for animals
  - Anachronistic
  - Breaks realism theme

## Testing

Check tests you have performed:
- [ ] Compiles without warnings
- [ ] Game runs without errors
- [ ] (For compatibility patches) ...with and without patched mod loaded
- [ ] Playtested a colony (specify how long)
